### PR TITLE
Ability to guard access to locations that don't match path blueprints

### DIFF
--- a/lib/src/beam_guard.dart
+++ b/lib/src/beam_guard.dart
@@ -12,6 +12,7 @@ class BeamGuard {
     @required this.check,
     this.beamTo,
     this.showPage,
+    this.blockNonMatchingLocations = false,
   }) : assert(beamTo != null || showPage != null);
 
   /// A list of path strings that are to be guarded.
@@ -22,7 +23,7 @@ class BeamGuard {
   /// but will not match '/books'. To match '/books' and everything after it,
   /// use '/books*'.
   ///
-  /// See [hasMatch] for more details.
+  /// See [_hasMatch] for more details.
   List<String> pathBlueprints;
 
   /// What check should guard perform on a given [location], the one that is
@@ -43,12 +44,16 @@ class BeamGuard {
   /// the conditions necessary to pass guard and rebuilds the tree.
   Widget showPage;
 
+  /// Whether or not [location]s matching the [pathBlueprint]s will be blocked,
+  /// or all other [location]s that don't match the [pathBlueprint]s will be.
+  bool blockNonMatchingLocations;
+
   /// Matches [location]'s pathBlueprint to [pathBlueprints].
   ///
   /// If asterisk is present, it is enough that the pre-asterisk substring is
   /// contained within location's pathBlueprint.
   /// Else, they must be equal.
-  bool hasMatch(BeamLocation location) {
+  bool _hasMatch(BeamLocation location) {
     for (var pathBlueprint in pathBlueprints) {
       final asteriskIndex = pathBlueprint.indexOf('*');
       if (asteriskIndex != -1) {
@@ -63,5 +68,12 @@ class BeamGuard {
       }
     }
     return false;
+  }
+
+  // Whether or not the guard should check access to the current [location]
+  bool shouldBlock(BeamLocation location) {
+    return blockNonMatchingLocations
+        ? !_hasMatch(location)
+        : _hasMatch(location);
   }
 }

--- a/lib/src/beamer_router_delegate.dart
+++ b/lib/src/beamer_router_delegate.dart
@@ -162,12 +162,12 @@ class BeamerRouterDelegate extends RouterDelegate<BeamLocation>
 
   BeamGuard _guardCheck(BuildContext context, BeamLocation location) {
     for (var guard in guards) {
-      if (guard.hasMatch(location) && guard.check(context, location) == false) {
+      if (guard.shouldBlock(location) && !guard.check(context, location)) {
         return guard;
       }
     }
     for (var guard in location.guards) {
-      if (guard.hasMatch(location) && guard.check(context, location) == false) {
+      if (guard.shouldBlock(location) && !guard.check(context, location)) {
         return guard;
       }
     }

--- a/test/beam_guard_test.dart
+++ b/test/beam_guard_test.dart
@@ -1,0 +1,126 @@
+import 'package:beamer/beamer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_locations.dart';
+
+void main() {
+  final testLocation = Location1(pathBlueprint: '/li/one');
+
+  group('shouldBlock', () {
+    test('is true if the location has a blueprint matching the guard', () {
+      final guard = BeamGuard(
+        pathBlueprints: [
+          testLocation.pathBlueprint,
+        ],
+        check: (_, __) => true,
+        beamTo: (context) => Location2(),
+      );
+
+      expect(guard.shouldBlock(testLocation), isTrue);
+    });
+
+    test("is false if the location doesn't have a blueprint matching the guard",
+        () {
+      final guard = BeamGuard(
+        pathBlueprints: ['/not-a-match'],
+        check: (_, __) => true,
+        beamTo: (context) => Location2(),
+      );
+
+      expect(guard.shouldBlock(testLocation), isFalse);
+    });
+
+    group('with wildcards', () {
+      test('is true if the location has a match up to the wildcard', () {
+        final guard = BeamGuard(
+          pathBlueprints: [
+            testLocation.pathBlueprint.substring(
+                  0,
+                  testLocation.pathBlueprint.indexOf('/'),
+                ) +
+                '/*',
+          ],
+          check: (_, __) => true,
+          beamTo: (context) => Location2(),
+        );
+
+        expect(guard.shouldBlock(testLocation), isTrue);
+      });
+
+      test("is false if the location doesn't have a match against the wildcard",
+          () {
+        final guard = BeamGuard(
+          pathBlueprints: [
+            '/not-a-match/*',
+          ],
+          check: (_, __) => true,
+          beamTo: (context) => Location2(),
+        );
+
+        expect(guard.shouldBlock(testLocation), isFalse);
+      });
+    });
+
+    group('when the guard is set to block other locations', () {
+      test('is false if the location has a blueprint matching the guard', () {
+        final guard = BeamGuard(
+          pathBlueprints: [
+            testLocation.pathBlueprint,
+          ],
+          check: (_, __) => true,
+          beamTo: (context) => Location2(),
+          blockNonMatchingLocations: true,
+        );
+
+        expect(guard.shouldBlock(testLocation), isFalse);
+      });
+
+      test(
+          "is true if the location doesn't have a blueprint matching the guard",
+          () {
+        final guard = BeamGuard(
+          pathBlueprints: ['/not-a-match'],
+          check: (_, __) => true,
+          beamTo: (context) => Location2(),
+          blockNonMatchingLocations: true,
+        );
+
+        expect(guard.shouldBlock(testLocation), isTrue);
+      });
+
+      group('with wildcards', () {
+        test('is false if the location has a match up to the wildcard', () {
+          final guard = BeamGuard(
+            pathBlueprints: [
+              testLocation.pathBlueprint.substring(
+                    0,
+                    testLocation.pathBlueprint.indexOf('/'),
+                  ) +
+                  '/*',
+            ],
+            check: (_, __) => true,
+            beamTo: (context) => Location2(),
+            blockNonMatchingLocations: true,
+          );
+
+          expect(guard.shouldBlock(testLocation), isFalse);
+        });
+
+        test(
+            "is true if the location doesn't have a match against the wildcard",
+            () {
+          final guard = BeamGuard(
+            pathBlueprints: [
+              '/not-a-match/*',
+            ],
+            check: (_, __) => true,
+            beamTo: (context) => Location2(),
+            blockNonMatchingLocations: true,
+          );
+
+          expect(guard.shouldBlock(testLocation), isTrue);
+        });
+      });
+    });
+  });
+}

--- a/test/beamer_test.dart
+++ b/test/beamer_test.dart
@@ -1,67 +1,8 @@
+import 'package:beamer/beamer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:beamer/beamer.dart';
-
-class Location1 extends BeamLocation {
-  Location1({
-    String pathBlueprint,
-    Map<String, String> pathParameters,
-    Map<String, String> queryParameters,
-    Map<String, dynamic> data,
-  }) : super(
-          pathBlueprint: pathBlueprint,
-          pathParameters: pathParameters,
-          queryParameters: queryParameters,
-          data: data,
-        );
-
-  @override
-  List<BeamPage> get pages => [
-        BeamPage(
-          key: ValueKey('l1'),
-          child: Container(),
-        ),
-        if (pathSegments.contains('one'))
-          BeamPage(
-            key: ValueKey('l1-one'),
-            child: Container(),
-          ),
-        if (pathSegments.contains('two'))
-          BeamPage(
-            key: ValueKey('l1-two'),
-            child: Container(),
-          )
-      ];
-
-  @override
-  List<String> get pathBlueprints => ['/l1/one', '/l1/two'];
-}
-
-class Location2 extends BeamLocation {
-  Location2({
-    String pathBlueprint,
-    Map<String, String> pathParameters,
-    Map<String, String> queryParameters,
-    Map<String, dynamic> data,
-  }) : super(
-          pathBlueprint: pathBlueprint,
-          pathParameters: pathParameters,
-          queryParameters: queryParameters,
-          data: data,
-        );
-
-  @override
-  List<BeamPage> get pages => [
-        BeamPage(
-          key: ValueKey('l2'),
-          child: Container(),
-        )
-      ];
-
-  @override
-  List<String> get pathBlueprints => ['/l2/:id'];
-}
+import 'test_locations.dart';
 
 void main() {
   final location1 = Location1(pathBlueprint: '/l1');

--- a/test/test_locations.dart
+++ b/test/test_locations.dart
@@ -1,0 +1,62 @@
+import 'package:beamer/beamer.dart';
+import 'package:flutter/material.dart';
+
+class Location1 extends BeamLocation {
+  Location1({
+    String pathBlueprint,
+    Map<String, String> pathParameters,
+    Map<String, String> queryParameters,
+    Map<String, dynamic> data,
+  }) : super(
+          pathBlueprint: pathBlueprint,
+          pathParameters: pathParameters,
+          queryParameters: queryParameters,
+          data: data,
+        );
+
+  @override
+  List<BeamPage> get pages => [
+        BeamPage(
+          key: ValueKey('l1'),
+          child: Container(),
+        ),
+        if (pathSegments.contains('one'))
+          BeamPage(
+            key: ValueKey('l1-one'),
+            child: Container(),
+          ),
+        if (pathSegments.contains('two'))
+          BeamPage(
+            key: ValueKey('l1-two'),
+            child: Container(),
+          )
+      ];
+
+  @override
+  List<String> get pathBlueprints => ['/l1/one', '/l1/two'];
+}
+
+class Location2 extends BeamLocation {
+  Location2({
+    String pathBlueprint,
+    Map<String, String> pathParameters,
+    Map<String, String> queryParameters,
+    Map<String, dynamic> data,
+  }) : super(
+          pathBlueprint: pathBlueprint,
+          pathParameters: pathParameters,
+          queryParameters: queryParameters,
+          data: data,
+        );
+
+  @override
+  List<BeamPage> get pages => [
+        BeamPage(
+          key: ValueKey('l2'),
+          child: Container(),
+        )
+      ];
+
+  @override
+  List<String> get pathBlueprints => ['/l2/:id'];
+}


### PR DESCRIPTION
Add a boolean that reverses guard checks, useful for apps that require authorised users throughout, for example, block all locations that don't match `['/', 'login', 'register']`.
