### PR TITLE
Add `name` attribute to `BeamPage`

### DIFF
--- a/lib/src/beam_page.dart
+++ b/lib/src/beam_page.dart
@@ -4,9 +4,10 @@ import 'package:flutter/material.dart';
 class BeamPage extends Page {
   BeamPage({
     Key key,
+    String name,
     @required this.child,
     this.keepQueryOnPop = false,
-  }) : super(key: key);
+  }) : super(key: key, name: name);
 
   /// The concrete Widget representing app's screen.
   final Widget child;


### PR DESCRIPTION
Sorry for yet another tiny pull request, I know the overhead of releases adds up.

This adds the ability to pass through page names that navigator observers can use. Again, it's quite useful for debugging and error reporting to follow through the navigation paths that users have taken.

For example,
![image](https://user-images.githubusercontent.com/9349865/107871639-5e73c900-6f08-11eb-9fcf-4ee7b3510d6c.png)

