### PR TITLE
add beamToNamed property to beam guard

### DIFF
--- a/package/lib/src/beam_guard.dart
+++ b/package/lib/src/beam_guard.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 
-import './beam_page.dart';
 import './beam_location.dart';
+import './beam_page.dart';
 
 /// A guard for [BeamLocation]s.
 ///
@@ -13,9 +13,10 @@ class BeamGuard {
     required this.check,
     this.onCheckFailed,
     this.beamTo,
+    this.beamToNamed,
     this.showPage,
     this.guardNonMatching = false,
-  }) : assert(beamTo != null || showPage != null);
+  }) : assert(beamTo != null || beamToNamed != null || showPage != null);
 
   /// A list of path strings that are to be guarded.
   ///
@@ -43,6 +44,11 @@ class BeamGuard {
   ///
   /// This has precedence over [showPage].
   BeamLocation Function(BuildContext context)? beamTo;
+
+  /// If guard [check] returns false, beam to this uri.
+  ///
+  /// This has precedence over [showPage].
+  String? beamToNamed;
 
   /// If guard [check] returns false, put this page onto navigation stack.
   ///

--- a/package/lib/src/beamer_router_delegate.dart
+++ b/package/lib/src/beamer_router_delegate.dart
@@ -240,6 +240,13 @@ class BeamerRouterDelegate extends RouterDelegate<Uri>
     if (guard?.beamTo != null) {
       _beamHistory.add(guard!.beamTo!(context)..prepare());
       _currentLocation = _beamHistory.last;
+    } else if (guard?.beamToNamed != null) {
+      final location = Utils.chooseBeamLocation(
+        Uri.parse(guard!.beamToNamed!),
+        beamLocations,
+      );
+      _beamHistory.add(location..prepare());
+      _currentLocation = _beamHistory.last;
     } else if ((_currentLocation is NotFound) && notFoundRedirect != null) {
       _currentLocation = notFoundRedirect!..prepare();
     }
@@ -253,7 +260,9 @@ class BeamerRouterDelegate extends RouterDelegate<Uri>
           observers: navigatorObservers,
           pages: _currentLocation is NotFound
               ? [notFoundPage]
-              : guard == null || guard.beamTo != null
+              : guard == null ||
+                      guard.beamTo != null ||
+                      guard.beamToNamed != null
                   ? _currentPages!
                   : [guard.showPage!],
           onPopPage: (route, result) {

--- a/package/test/beam_guard_test.dart
+++ b/package/test/beam_guard_test.dart
@@ -1,4 +1,5 @@
 import 'package:beamer/beamer.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'test_locations.dart';
@@ -119,6 +120,62 @@ void main() {
 
           expect(guard.shouldGuard(testLocation), isTrue);
         });
+      });
+    });
+
+    group('guard updates location on build', () {
+      final targetLocation = Location2(pathBlueprint: '/l2');
+      final fallbackLocation = CustomStateLocation();
+
+      testWidgets('guard beamTo changes the location on build', (tester) async {
+        var router = BeamerRouterDelegate(
+          beamLocations: [testLocation, targetLocation, fallbackLocation],
+          guards: [
+            BeamGuard(
+                pathBlueprints: ['/l2'],
+                check: (context, loc) => false,
+                beamTo: (context) => fallbackLocation),
+          ],
+        );
+
+        await tester.pumpWidget(MaterialApp.router(
+          routerDelegate: router,
+          routeInformationParser: BeamerRouteInformationParser(),
+        ));
+
+        expect(router.currentLocation, equals(testLocation));
+
+        router.beamTo(targetLocation);
+        await tester.pump();
+
+        expect(router.currentLocation, equals(fallbackLocation));
+      });
+
+      testWidgets('guard beamToNamed changes the location on build',
+          (tester) async {
+        var router = BeamerRouterDelegate(
+          beamLocations: [testLocation, targetLocation, fallbackLocation],
+          guards: [
+            BeamGuard(
+                pathBlueprints: ['/l2'],
+                check: (context, loc) => false,
+                beamToNamed: '/custom/123'),
+          ],
+        );
+
+        await tester.pumpWidget(MaterialApp.router(
+          routerDelegate: router,
+          routeInformationParser: BeamerRouteInformationParser(),
+        ));
+
+        expect(router.currentLocation, equals(testLocation));
+
+        router.beamTo(targetLocation);
+        await tester.pump();
+
+        expect(router.currentLocation, isA<CustomStateLocation>());
+        expect(router.currentLocation.state.pathParameters,
+            equals({'customVar': '123'}));
       });
     });
   });


### PR DESCRIPTION
Resolves #140 

I also added two widget tests that test the correct handling of guard locations when the check fails, one for beamTo and one for the new beamToNamed.