### PR TITLE
[Add] `setPathUrlStrategy` method to `Beamer`

### DIFF
--- a/package/lib/src/beamer.dart
+++ b/package/lib/src/beamer.dart
@@ -6,6 +6,8 @@ import 'beam_location.dart';
 import 'beamer_back_button_dispatcher.dart';
 import 'beamer_router_delegate.dart';
 import 'beamer_provider.dart';
+import 'path_url_strategy_nonweb.dart'
+    if (dart.library.html) 'path_url_strategy_web.dart' as url_strategy;
 
 /// A wrapper for [Router].
 class Beamer extends StatefulWidget {
@@ -32,6 +34,11 @@ class Beamer extends StatefulWidget {
     }
     return _delegate;
   }
+
+  /// Change the strategy to use for handling browser URL to [PathUrlStrategy].
+  ///
+  /// [PathUrlStrategy] uses the browser URL's pathname to represent Beamer's route name.
+  static void setPathUrlStrategy() => url_strategy.setPathUrlStrategy();
 
   @override
   State<StatefulWidget> createState() => BeamerState();

--- a/package/lib/src/beamer_router_delegate.dart
+++ b/package/lib/src/beamer_router_delegate.dart
@@ -3,6 +3,8 @@ import 'package:beamer/src/transition_delegates.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'path_url_strategy_nonweb.dart'
+    if (dart.library.html) 'path_url_strategy_web.dart' as url_strategy;
 
 /// A delegate that is used by the [Router] to build the [Navigator].
 class BeamerRouterDelegate<T extends BeamState> extends RouterDelegate<Uri>
@@ -405,6 +407,11 @@ class BeamerRouterDelegate<T extends BeamState> extends RouterDelegate<Uri>
   /// Remove everything except last from [beamLocationHistory].
   void clearBeamLocationHistory() =>
       _beamLocationHistory.removeRange(0, _beamLocationHistory.length - 1);
+
+  /// Change the strategy to use for handling browser URL to [PathUrlStrategy].
+  ///
+  /// [PathUrlStrategy] uses the browser URL's pathname to represent Beamer's route name.
+  void setPathUrlStrategy() => url_strategy.setPathUrlStrategy();
 
   @override
   Uri? get currentConfiguration =>

--- a/package/lib/src/beamer_router_delegate.dart
+++ b/package/lib/src/beamer_router_delegate.dart
@@ -3,8 +3,6 @@ import 'package:beamer/src/transition_delegates.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'path_url_strategy_nonweb.dart'
-    if (dart.library.html) 'path_url_strategy_web.dart' as url_strategy;
 
 /// A delegate that is used by the [Router] to build the [Navigator].
 class BeamerRouterDelegate<T extends BeamState> extends RouterDelegate<Uri>
@@ -407,11 +405,6 @@ class BeamerRouterDelegate<T extends BeamState> extends RouterDelegate<Uri>
   /// Remove everything except last from [beamLocationHistory].
   void clearBeamLocationHistory() =>
       _beamLocationHistory.removeRange(0, _beamLocationHistory.length - 1);
-
-  /// Change the strategy to use for handling browser URL to [PathUrlStrategy].
-  ///
-  /// [PathUrlStrategy] uses the browser URL's pathname to represent Beamer's route name.
-  void setPathUrlStrategy() => url_strategy.setPathUrlStrategy();
 
   @override
   Uri? get currentConfiguration =>

--- a/package/lib/src/path_url_strategy_nonweb.dart
+++ b/package/lib/src/path_url_strategy_nonweb.dart
@@ -1,0 +1,3 @@
+void setPathUrlStrategy() {
+  // No-op.
+}

--- a/package/lib/src/path_url_strategy_web.dart
+++ b/package/lib/src/path_url_strategy_web.dart
@@ -1,0 +1,3 @@
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+void setPathUrlStrategy() => setUrlStrategy(PathUrlStrategy());

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -11,6 +11,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_web_plugins:
+    sdk: flutter
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR adds a method called `setPathUrlStrategy` to `BeamerRouterDelegate` which changes the strategy to use for handling browser URL to `PathUrlStrategy`. This means the hashtag in the URL is removed.

With this PR you no longer need to import an extra package for that or write the code on your own, you just need to call `setPathUrlStrategy` on your `BeamerRouterDelegate`. Example:

```
final beamerDelegate = BeamerRouterDelegate(
  locationBuilder: SimpleLocationBuilder(
    routes: {
      '/': (context) => Home(),
      '/page1': (context) => Page1(),
    },
  ),
)..setPathUrlStrategy();
```