### PR TITLE
[Add] setBrowserTabTitle attribute to BeamerRouterDelegate

### DIFF
--- a/package/lib/src/beamer_router_delegate.dart
+++ b/package/lib/src/beamer_router_delegate.dart
@@ -22,6 +22,7 @@ class BeamerRouterDelegate<T extends BeamState> extends RouterDelegate<Uri>
     this.transitionDelegate = const DefaultTransitionDelegate(),
     this.beamBackTransitionDelegate = const ReverseTransitionDelegate(),
     this.onPopPage,
+    this.updateBrowserTabTitle = true,
   }) {
     notFoundPage ??= BeamPage(
       child: Container(child: Center(child: Text('Not found'))),
@@ -147,6 +148,10 @@ class BeamerRouterDelegate<T extends BeamState> extends RouterDelegate<Uri>
   /// See [build] for details on how beamer handles [Navigator.onPopPage].
   bool Function(BuildContext context, Route<dynamic> route, dynamic result)?
       onPopPage;
+
+  /// Whether or not the title attribute of [BeamPage] should be used
+  /// to update the browser tab title when beaming.
+  final bool updateBrowserTabTitle;
 
   final GlobalKey<NavigatorState> _navigatorKey = GlobalKey<NavigatorState>();
 
@@ -465,7 +470,7 @@ class BeamerRouterDelegate<T extends BeamState> extends RouterDelegate<Uri>
         if (_currentPages.isEmpty) {
           _currentLocation =
               NotFound(path: _currentLocation.state.uri.toString());
-        } else if (kIsWeb) {
+        } else if (kIsWeb && updateBrowserTabTitle) {
           // Set the browser tab title:
           SystemChrome.setApplicationSwitcherDescription(
               ApplicationSwitcherDescription(

--- a/package/lib/src/beamer_router_delegate.dart
+++ b/package/lib/src/beamer_router_delegate.dart
@@ -22,7 +22,7 @@ class BeamerRouterDelegate<T extends BeamState> extends RouterDelegate<Uri>
     this.transitionDelegate = const DefaultTransitionDelegate(),
     this.beamBackTransitionDelegate = const ReverseTransitionDelegate(),
     this.onPopPage,
-    this.updateBrowserTabTitle = true,
+    this.setBrowserTabTitle = true,
   }) {
     notFoundPage ??= BeamPage(
       child: Container(child: Center(child: Text('Not found'))),
@@ -149,9 +149,9 @@ class BeamerRouterDelegate<T extends BeamState> extends RouterDelegate<Uri>
   bool Function(BuildContext context, Route<dynamic> route, dynamic result)?
       onPopPage;
 
-  /// Whether or not the title attribute of [BeamPage] should be used
-  /// to update the browser tab title when beaming.
-  final bool updateBrowserTabTitle;
+  /// Whether the title attribute of [BeamPage] should
+  /// be used to set and update the browser tab title.
+  final bool setBrowserTabTitle;
 
   final GlobalKey<NavigatorState> _navigatorKey = GlobalKey<NavigatorState>();
 
@@ -470,7 +470,7 @@ class BeamerRouterDelegate<T extends BeamState> extends RouterDelegate<Uri>
         if (_currentPages.isEmpty) {
           _currentLocation =
               NotFound(path: _currentLocation.state.uri.toString());
-        } else if (kIsWeb && updateBrowserTabTitle) {
+        } else if (kIsWeb && setBrowserTabTitle) {
           // Set the browser tab title:
           SystemChrome.setApplicationSwitcherDescription(
               ApplicationSwitcherDescription(


### PR DESCRIPTION
With this PR we have the option to turn the `updateBrowserTabTitle` feature on or off 🙂

I turned it on by default. Or what do you think?