### PR TITLE
Added an alternative LocationBuilder using path to regexp

### DIFF
--- a/examples/location_builders/lib/location_builders.dart
+++ b/examples/location_builders/lib/location_builders.dart
@@ -39,6 +39,34 @@ final beamerLocationBuilder = BeamerLocationBuilder(
   ],
 );
 
+// OPTION C:
+final path2regexpLocationBuilder = PathLocationBuilder(
+  routes: {
+    '/': (context, state, data) => BeamPage(
+          key: ValueKey('home'),
+          title: 'Home',
+          child: HomeScreen(),
+        ),
+    '/books': (context, state, data) => BeamPage(
+          key: ValueKey('books'),
+          title: 'Books',
+          child: BooksScreen(),
+        ),
+    '/books/:bookId': (context, state, data) {
+      final book = books.firstWhere((book) =>
+          book['id'] ==
+          (context.currentBeamLocation.state as BeamState)
+              .pathParameters['bookId']);
+
+      return BeamPage(
+        key: ValueKey('book-${book['id']}'),
+        title: book['title'],
+        child: BookDetailsScreen(book: book),
+      );
+    }
+  },
+);
+
 class BooksLocation extends BeamLocation<BeamState> {
   BooksLocation({RouteInformation? routeInformation}) : super(routeInformation);
 

--- a/examples/location_builders/lib/main.dart
+++ b/examples/location_builders/lib/main.dart
@@ -14,9 +14,12 @@ class MyApp extends StatelessWidget {
     locationBuilder: simpleLocationBuilder,
     //
     // OPTION B:
-    //locationBuilder: beamerLocationBuilder,
+    // locationBuilder: beamerLocationBuilder,
     //
     // OPTION C:
+    // locationBuilder: path2regexpLocationBuilder,
+    //
+    // OPTION D:
     // locationBuilder: (routeInformation) =>
     //     BooksLocation(routeInformation: routeInformation),
   );

--- a/package/lib/src/location_builders.dart
+++ b/package/lib/src/location_builders.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:beamer/beamer.dart';
 import 'package:beamer/src/utils.dart';
+import 'package:path_to_regexp_port/path_to_regexp_port.dart';
 
 /// A convenience typedef for [BeamerDelegate.locationBuilder].
 typedef LocationBuilder = BeamLocation Function(
@@ -66,6 +67,80 @@ class RoutesLocationBuilder {
       return RoutesBeamLocation(
         routeInformation: routeInformation,
         routes: routes,
+        navBuilder: builder,
+      );
+    } else {
+      return NotFound(path: routeInformation.location ?? '/');
+    }
+  }
+}
+
+/// A pre-made builder to be used for [BeamerDelegate.locationBuilder].
+///
+/// Creates a single [BeamLocation]; [RoutesBeamLocation]
+/// and configures its [BeamLocation.buildPages] from specified [routes].
+///
+/// Uses an Path2Regex interpreter to build flexible paths
+class PathLocationBuilder {
+  /// Creates a [PathLocationBuilder] with specified properties.
+  ///
+  /// [routes] are required to build pages from.
+  PathLocationBuilder({
+    required this.routes,
+    this.builder,
+    this.end = true,
+  });
+
+  /// When 'true' the regexp will match to the end of the string
+  final bool end;
+
+  /// List of all routes this builder handles.
+  final Map<String, dynamic Function(BuildContext, BeamState, Object?)> routes;
+
+  /// Used as a [BeamLocation.builder].
+  Widget Function(BuildContext context, Widget navigator)? builder;
+
+  /// Makes this callable as [LocationBuilder].
+  ///
+  /// Returns [RoutesBeamLocation] configured with chosen routes from [routes] or [NotFound].
+  BeamLocation call(
+    RouteInformation routeInformation,
+    BeamParameters? beamParameters,
+  ) {
+    final nextRoutes = routes.entries
+        .fold<Map<Pattern, dynamic Function(BuildContext, BeamState, Object?)>>(
+      {},
+      (previousValue, element) {
+        final pattern = pathToRegexp(element.key, [], end: end);
+
+        previousValue[pattern] = (context, state, obj) {
+          final match = pattern.firstMatch(state.uri.toString());
+          final pathParameters = match?.groupNames.fold<Map<String, String>>(
+                {},
+                (previousValue, element) {
+                  previousValue[element] = match.namedGroup(element)!;
+                  return previousValue;
+                },
+              ) ??
+              {};
+
+          return element.value(
+            context,
+            state.copyWith(pathParameters: pathParameters),
+            obj,
+          );
+        };
+
+        return previousValue;
+      },
+    );
+
+    final matched =
+        RoutesBeamLocation.chooseRoutes(routeInformation, nextRoutes.keys);
+    if (matched.isNotEmpty) {
+      return RoutesBeamLocation(
+        routeInformation: routeInformation,
+        routes: nextRoutes,
         navBuilder: builder,
       );
     } else {

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
+  path_to_regexp_port: ^1.0.2
 
 dev_dependencies:
   flutter_lints: ^1.0.4


### PR DESCRIPTION
Not sure if this is wanted due to the external dependency, but I have earlier found the need for a more flexible path syntax than the included syntax path syntax in beamer. 

In several js navigation libraries path-to-regexp has been the go to library to build this kinds of paths so here is a suggestion for an extra LocationBuilder supporting the path-to-regexp syntax