### PR TITLE
Make BeamPage.key required

### DIFF
--- a/package/lib/src/beam_page.dart
+++ b/package/lib/src/beam_page.dart
@@ -31,8 +31,10 @@ class BeamPage extends Page {
   /// Creates a [BeamPage] with specified properties.
   ///
   /// [child] is required and typically represents a screen of the app.
+  /// 
+  /// [key] is required since [Navigator] needs it to tell [BeamPage]s apart. 
   const BeamPage({
-    LocalKey? key,
+    required LocalKey key,
     String? name,
     required this.child,
     this.title,

--- a/package/test/beam_page_test.dart
+++ b/package/test/beam_page_test.dart
@@ -456,6 +456,7 @@ void main() {
             '/': (context, state, data) => Container(),
             '/test': (context, state, data) => Container(),
             '/test/2': (context, state, data) => BeamPage(
+                  key: const ValueKey('/test/2'),
                   onPopPage: BeamPage.routePop,
                   child: Container(),
                 ),


### PR DESCRIPTION
Force `BeamPage.key` to be set in order for `Navigator` to be able to tell `BeamPage`s apart.