### PR TITLE
_initializeFromParent initialPath fix

### DIFF
--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -1,9 +1,8 @@
 import 'package:beamer/beamer.dart';
+import 'package:beamer/src/utils.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
-import 'package:beamer/src/utils.dart';
 
 /// A delegate that is used by the [Router] to build the [Navigator].
 ///
@@ -906,7 +905,9 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     if (parent == null) {
       return;
     }
-    configuration = parent.configuration.copyWith();
+    configuration = updateFromParent
+        ? parent.configuration.copyWith()
+        : parent.configuration.copyWith(location: initialPath);
     var location = locationBuilder(
       configuration,
       _currentBeamParameters.copyWith(),

--- a/package/test/beamer_delegate_test.dart
+++ b/package/test/beamer_delegate_test.dart
@@ -402,13 +402,19 @@ void main() {
       rootDelegate.beamToNamed('/test'); // initial will update
       await tester.pump();
       expect(rootDelegate.configuration.location, '/test');
-      expect(childDelegate.configuration.location, '/test');
+      childDelegate.updateFromParent
+          ? expect(childDelegate.configuration.location, '/test')
+          : expect(
+              childDelegate.configuration.location, childDelegate.initialPath);
       expect(childDelegate.beamingHistory.last.history.length, 1);
 
       rootDelegate.beamToNamed('/test2');
       await tester.pump();
       expect(rootDelegate.configuration.location, '/test2');
-      expect(childDelegate.configuration.location, '/test');
+      childDelegate.updateFromParent
+          ? expect(childDelegate.configuration.location, '/test')
+          : expect(
+              childDelegate.configuration.location, childDelegate.initialPath);
       expect(childDelegate.beamingHistory.last.history.length, 1);
     });
   });

--- a/package/test/beamer_delegate_test.dart
+++ b/package/test/beamer_delegate_test.dart
@@ -402,19 +402,13 @@ void main() {
       rootDelegate.beamToNamed('/test'); // initial will update
       await tester.pump();
       expect(rootDelegate.configuration.location, '/test');
-      childDelegate.updateFromParent
-          ? expect(childDelegate.configuration.location, '/test')
-          : expect(
-              childDelegate.configuration.location, childDelegate.initialPath);
+      expect(childDelegate.configuration.location, childDelegate.initialPath);
       expect(childDelegate.beamingHistory.last.history.length, 1);
 
       rootDelegate.beamToNamed('/test2');
       await tester.pump();
       expect(rootDelegate.configuration.location, '/test2');
-      childDelegate.updateFromParent
-          ? expect(childDelegate.configuration.location, '/test')
-          : expect(
-              childDelegate.configuration.location, childDelegate.initialPath);
+      expect(childDelegate.configuration.location, childDelegate.initialPath);
       expect(childDelegate.beamingHistory.last.history.length, 1);
     });
   });

--- a/package/test/beamer_delegate_test.dart
+++ b/package/test/beamer_delegate_test.dart
@@ -355,7 +355,7 @@ void main() {
         ),
       );
 
-      rootDelegate.beamToNamed('/test');
+      rootDelegate.beamToNamed('/test'); // initial will update
       await tester.pump();
       expect(rootDelegate.configuration.location, '/test');
       expect(childDelegate.configuration.location, '/test');
@@ -399,7 +399,7 @@ void main() {
         ),
       );
 
-      rootDelegate.beamToNamed('/test'); // initial will update
+      rootDelegate.beamToNamed('/test');
       await tester.pump();
       expect(rootDelegate.configuration.location, '/test');
       expect(childDelegate.configuration.location, childDelegate.initialPath);


### PR DESCRIPTION
Issue: 
When creating multiple `BeamerDelegate`, the child `BeamerDelegate`'s first location is the parent delegate's last route. This should not be the case when a child `BeamerDelegate`'s `updateFromParent` is set to false. Instead the `initialPath` should be the first location.

Fix: 
A `BeamerDelegate` which was initialized from a parent `BeamerDelegate` will now check 'updateFromParent' to determine if the previous location or the `initialPath` should be the first location.