### PR TITLE
advanced_books sample gets error trying to list all books

### DIFF
--- a/examples/advanced_books/lib/location_builders.dart
+++ b/examples/advanced_books/lib/location_builders.dart
@@ -13,8 +13,9 @@ final simpleLocationBuilder = RoutesLocationBuilder(
           child: HomeScreen(),
         ),
     '/books': (context, state, data) {
-      final titleQuery =
-          state.queryParameters['title'] ?? (data as Map)['title'] ?? '';
+      final titleQuery = state.queryParameters['title'] ??
+          ((data ?? {}) as Map)['title'] ??
+          '';
       final genreQuery = state.queryParameters['genre'] ?? '';
       final pageTitle = titleQuery != ''
           ? "Books with name '$titleQuery'"


### PR DESCRIPTION
I'm using flutter 2.8.1 and dart 2.15.1.  For the advanced_books sample, when I click the "See all books" button it gets an error:

> Expected a value of type 'Map<dynamic, dynamic>', but got one of type 'Null'
>
> The relevant error-causing widget was
MaterialApp
lib/main.dart:23
When the exception was thrown, this was the stack
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 251:49      throw_
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 84:3        castError
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 452:10  cast
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/classes.dart 635:14     as_C
packages/advanced_books/location_builders.dart 17:60                              <fn>
...

The problem is at `location_builders.dart 17:60` in the code `state.queryParameters['title'] ?? (data as Map)['title'] ?? '';`.  The problem is data is Null so the cast to Map fails.  My solution is if data is null then pass an empty map to the cast.
