### PR TITLE
fix BeamerLocationBuilder in advanced_books sample

### DIFF
--- a/examples/advanced_books/lib/location_builders.dart
+++ b/examples/advanced_books/lib/location_builders.dart
@@ -117,7 +117,8 @@ class BooksLocation extends BeamLocation<BeamState> {
     final beamPages = [...HomeLocation().buildPages(context, state)];
 
     if (state.pathPatternSegments.contains('books')) {
-      final titleQuery = state.queryParameters['title'] ?? '';
+      final titleQuery =
+          state.queryParameters['title'] ?? (data as Map)['title'] ?? '';
       final genreQuery = state.queryParameters['genre'] ?? '';
       final pageTitle = titleQuery != ''
           ? "Books with name '$titleQuery'"


### PR DESCRIPTION
The fix for #399 in https://github.com/slovnicki/beamer/commit/99cfe274a6519937ce154f9e03f976fa94c3831f needs to also include the `BeamerLocationBuilder` that you can switch to in commented out 'option B'.  This is so it works the same for `BeamerLocationBuilder` and `RoutesLocationBuilder` (what used to be `SimpleLocationBuilder`)