### PR TITLE
Bug/486 nested navigation leads to crash

### DIFF
--- a/package/lib/src/beamer.dart
+++ b/package/lib/src/beamer.dart
@@ -57,7 +57,7 @@ class Beamer extends StatefulWidget {
 /// A [State] for [Beamer].
 class BeamerState extends State<Beamer> {
   /// A parent Router of this Beamer / Router.
-  late Router parent;
+  late Router? parent;
 
   /// A getter for [BeamerDelegate] of the [Beamer] whose state is this.
   BeamerDelegate get routerDelegate => widget.routerDelegate;
@@ -69,17 +69,26 @@ class BeamerState extends State<Beamer> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     parent = Router.of(context);
-    routerDelegate.parent = parent.routerDelegate as BeamerDelegate;
+    routerDelegate.parent = parent!.routerDelegate as BeamerDelegate;
+  }
+  
+  @override
+  void dispose() {
+    parent = null; 
+    routerDelegate.parent = null;
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    // The parent will only be null, if this state is disposed and therefore 
+    // `build` cannot be called on it any more.
     final backButtonDispatcher = widget.backButtonDispatcher ??
-        ((parent.backButtonDispatcher is BeamerBackButtonDispatcher &&
+        ((parent!.backButtonDispatcher is BeamerBackButtonDispatcher &&
                 widget.createBackButtonDispatcher)
             ? BeamerChildBackButtonDispatcher(
                 parent:
-                    parent.backButtonDispatcher! as BeamerBackButtonDispatcher,
+                    parent!.backButtonDispatcher! as BeamerBackButtonDispatcher,
                 delegate: routerDelegate,
               )
             : null);

--- a/package/lib/src/beamer.dart
+++ b/package/lib/src/beamer.dart
@@ -71,13 +71,6 @@ class BeamerState extends State<Beamer> {
     parent = Router.of(context);
     routerDelegate.parent = parent!.routerDelegate as BeamerDelegate;
   }
-  
-  @override
-  void dispose() {
-    parent = null; 
-    routerDelegate.parent = null;
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -96,6 +89,13 @@ class BeamerState extends State<Beamer> {
       routerDelegate: routerDelegate,
       backButtonDispatcher: backButtonDispatcher?..takePriority(),
     );
+  }
+
+  @override
+  void dispose() {
+    parent = null;
+    routerDelegate.parent = null;
+    super.dispose();
   }
 }
 

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -74,7 +74,13 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
   /// `*App.router` and at least one more [Beamer] in the Widget tree.
   BeamerDelegate? get parent => _parent;
   set parent(BeamerDelegate? parent) {
-    if (parent == null || _parent == parent) {
+    if(parent == null && _parent != null) {
+      _parent!.removeListener(_updateFromParent);
+      _parent!._children.remove(this);
+      _parent = null;
+      return;
+    }
+    if (_parent == parent) {
       return;
     }
     _parent = parent;
@@ -398,7 +404,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
 
     // run guards on _beamLocationCandidate
     final context = _context;
-    if (context != null && context is Element && (context as Element).dirty == false) {      
+    if (context != null) {
       final didApply = _runGuards(context, _beamLocationCandidate);
       _didRunGuards = true;
       if (didApply) {

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -397,7 +397,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     }
 
     // run guards on _beamLocationCandidate
-    if (_context != null) {
+    if (_context != null && _context is Element && (_context as Element).dirty == false) {
       final didApply = _runGuards(_context!, _beamLocationCandidate);
       _didRunGuards = true;
       if (didApply) {
@@ -713,7 +713,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
   @override
   Widget build(BuildContext context) {
     _buildInProgress = true;
-    _context ??= context;
+    _context = context;
 
     if (!_didRunGuards) {
       _runGuards(_context!, _beamLocationCandidate);

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -397,8 +397,9 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     }
 
     // run guards on _beamLocationCandidate
-    if (_context != null && _context is Element && (_context as Element).dirty == false) {
-      final didApply = _runGuards(_context!, _beamLocationCandidate);
+    final context = _context;
+    if (context != null && context is Element && (context as Element).dirty == false) {      
+      final didApply = _runGuards(context, _beamLocationCandidate);
       _didRunGuards = true;
       if (didApply) {
         return;

--- a/package/test/nested_navigation.dart
+++ b/package/test/nested_navigation.dart
@@ -1,0 +1,155 @@
+import 'dart:async';
+
+import 'package:beamer/beamer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('nested navigation', () {
+    testWidgets(
+        'nested navigation does not crash, when child is removed from widget tree',
+        (tester) async {
+      final routerDelegate = BeamerDelegate(
+        initialPath: '/home',
+        notFoundRedirectNamed: '/home',
+        locationBuilder: RoutesLocationBuilder(
+          routes: {
+            '*': (context, state, data) => MainLocation(),
+          },
+        ),
+      );
+
+      final authenticationNotifier = AuthenticationNotifier(
+        child: MaterialApp.router(
+            routeInformationParser: BeamerParser(),
+            routerDelegate: routerDelegate,
+            backButtonDispatcher:
+                BeamerBackButtonDispatcher(delegate: routerDelegate)),
+      );
+
+      await tester.pumpWidget(MyApp(authenticationNotifier));
+
+      expect(
+          (routerDelegate.currentBeamLocation.state as BeamState)
+              .pathPatternSegments
+              .first,
+          'home');
+      authenticationNotifier.isUserAuthenticated = false;
+      authenticationNotifier.isAuthenticatedStreamController.add(false);
+
+      await tester.pumpAndSettle();
+      expect(
+          (routerDelegate.currentBeamLocation.state as BeamState)
+              .pathPatternSegments
+              .first,
+          'login');
+
+      authenticationNotifier.isUserAuthenticated = true;
+      authenticationNotifier.isAuthenticatedStreamController.add(true);
+
+      await tester.pumpAndSettle();
+      expect(
+          (routerDelegate.currentBeamLocation.state as BeamState)
+              .pathPatternSegments
+              .first,
+          'home');
+    });
+  });
+}
+
+class MyApp extends StatelessWidget {
+  AuthenticationNotifier _authenticationNotifier;
+  MyApp(this._authenticationNotifier, {Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return _authenticationNotifier;
+  }
+}
+
+class MainLocation extends StatefulWidget {
+  MainLocation({Key? key}) : super(key: key);
+
+  @override
+  State<MainLocation> createState() => _MainLocationState();
+}
+
+class _MainLocationState extends State<MainLocation> {
+  StreamSubscription? subscription;
+
+  final routerDelegate = BeamerDelegate(
+      guards: [
+        BeamGuard(
+            pathPatterns: ['/login'],
+            guardNonMatching: true,
+            check: (context, state) =>
+                AuthenticationNotifier.of(context).isUserAuthenticated,
+            beamToNamed: (origin, target) => '/login')
+      ],
+      clearBeamingHistoryOn: {
+        '/login'
+      },
+      updateParent: false,
+      locationBuilder: RoutesLocationBuilder(routes: {
+        '/home': (context, state, data) =>
+            const SomePage(key: ValueKey('home'), text: 'Home'),
+        '/login': (context, state, data) =>
+            const SomePage(key: ValueKey('login'), text: 'Login')
+      }));
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    subscription?.cancel();
+    var authenticationNotifier = AuthenticationNotifier.of(context);
+    subscription = authenticationNotifier.isAuthenticatedStreamController.stream
+        .listen((element) {
+      if (authenticationNotifier.isUserAuthenticated) {
+        context.beamToNamed('/home');
+      } else {
+        context.beamToNamed('/login');
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Beamer(routerDelegate: routerDelegate);
+  }
+
+  @override
+  void dispose() {
+    subscription?.cancel();
+    super.dispose();
+  }
+}
+
+class SomePage extends StatelessWidget {
+  final String text;
+
+  const SomePage({Key? key, required this.text}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: Center(child: Text(text)));
+  }
+}
+
+class AuthenticationNotifier extends InheritedWidget {
+  final StreamController<bool> isAuthenticatedStreamController =
+      StreamController<bool>.broadcast();
+  bool isUserAuthenticated = true;
+
+  AuthenticationNotifier({Key? key, required Widget child})
+      : super(key: key, child: child) {}
+
+  static AuthenticationNotifier of(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<AuthenticationNotifier>()!;
+  }
+
+  @override
+  bool updateShouldNotify(covariant InheritedWidget oldWidget) => true;
+}


### PR DESCRIPTION
Fixes #486

This cuts the dependencies of a child Beamer to its parent, if it is removed from the widget tree.