### PR TITLE
fix wildcard pattern matching for paths with multiple levels

### DIFF
--- a/package/lib/src/beam_location.dart
+++ b/package/lib/src/beam_location.dart
@@ -522,7 +522,7 @@ class RoutesBeamLocation extends BeamLocation<BeamState> {
           path += '/${uriPathSegments[i]}';
 
           if (routePathSegments[i] == '*') {
-            if (i == 0 || i == uriPathSegments.length - 1) {
+            if (i == 0 || i == routePathSegments.length - 1) {
               path = uri.path;
               overrideNotFound = true;
               break;

--- a/package/test/beam_location_test.dart
+++ b/package/test/beam_location_test.dart
@@ -135,4 +135,48 @@ void main() {
     delegate.beamToNamed('/');
     expect(delegate.currentBeamLocation, isA<NotFound>());
   });
+
+  group('pattern matching', () {
+    test('pattern matching works correctly when choosing routes', () {
+      void checkMatch(
+        String routeMatcher,
+        String routeToBeMatched,
+        bool shouldMatch,
+      ) {
+        expect(
+          RoutesBeamLocation.chooseRoutes(
+            RouteInformation(location: routeToBeMatched),
+            [routeMatcher],
+          ),
+          shouldMatch ? isNotEmpty : isEmpty,
+        );
+      }
+
+      checkMatch('/home', '/home', true);
+      checkMatch('/*', '/home', true);
+      checkMatch('/home/*', '/home/', true);
+      checkMatch('/home/*', '/home/one', true);
+      checkMatch('/home/*', '/home/one/two', true);
+      checkMatch('*', '/home', true);
+      checkMatch('*', '/home/one/two', true);
+      checkMatch('*', 'pretty much anything', true);
+      checkMatch('/*', '/home', true);
+      checkMatch('/*', 'home', true);
+      checkMatch('/*', '/home/one/two', true);
+      checkMatch('/*', 'home/one/two', true);
+      checkMatch('/*', '/leading slashes should be ignored', true);
+      checkMatch('/*', 'leading slashed should be ignored', true);
+
+      checkMatch('/', '/home', false);
+      checkMatch('/home', '/home/', false);
+      checkMatch('/home', '/home/one', false);
+      checkMatch('/home', '/home/one/two', false);
+      checkMatch('/home/*', '/home', false);
+      checkMatch('/home*', '/home/one', false);
+      checkMatch('*', '', false);
+      checkMatch('*', '/', false);
+      checkMatch('/*', '', false);
+      checkMatch('/*', '/', false);
+    });
+  });
 }


### PR DESCRIPTION
The commit 84d582e7acc80483e6303f6d2db3296f77ffc9f1 introduced a bug where the wildcard operator ('\*') would only match paths one level deep. For example '/home/\*' would match '/home/single', but not 'home/multiple/levels'.