### PR TITLE
Fix: popToNamed(...), need to break from the while loop when entry found

### DIFF
--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -74,7 +74,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
   /// `*App.router` and at least one more [Beamer] in the Widget tree.
   BeamerDelegate? get parent => _parent;
   set parent(BeamerDelegate? parent) {
-    if(parent == null && _parent != null) {
+    if (parent == null && _parent != null) {
       _parent!.removeListener(_updateFromParent);
       _parent!._children.remove(this);
       _parent = null;
@@ -609,6 +609,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
       } else {
         beamingHistory.last.history
             .removeRange(index, beamingHistory.last.history.length);
+        break;
       }
     }
     beamToNamed(

--- a/package/test/beamer_delegate_test.dart
+++ b/package/test/beamer_delegate_test.dart
@@ -706,4 +706,26 @@ void main() {
           '/t1/t2');
     });
   });
+  
+  test('description', () {
+    final delegate = BeamerDelegate(
+      locationBuilder: RoutesLocationBuilder(
+        routes: {
+          '/': (context, state, data) => Container(),
+          '/t1': (context, state, data) => Container(),
+          '/t2': (context, state, data) => Container(),
+          '/t3': (context, state, data) => Container(),
+        },
+      ),
+    );
+    delegate.beamToNamed('/t1');
+    delegate.beamToNamed('/t2');
+    delegate.beamToNamed('/t3');
+    delegate.popToNamed('/t2');
+
+    expect(
+        delegate.currentBeamLocation.history
+            .map((HistoryElement e) => e.routeInformation.location),
+        orderedEquals(<String>['/t1', '/t2']));
+  });
 }

--- a/package/test/beamer_delegate_test.dart
+++ b/package/test/beamer_delegate_test.dart
@@ -706,8 +706,8 @@ void main() {
           '/t1/t2');
     });
   });
-  
-  test('description', () {
+
+  test('Properly preserve history part when using popToNamed(...)', () {
     final delegate = BeamerDelegate(
       locationBuilder: RoutesLocationBuilder(
         routes: {


### PR DESCRIPTION
We found an issue where our complete history stack is always reset when using `popToNamed(...)`. Turns out that the while loop is missing a `break` when the actual entry has been found the entries following (including the entry itself) the entry have been removed. Because if we do not `break` here, we continue with the next while loop iteration, won't find the entry, and remove the last entry until no entries are left and we end up with an empty stack.