### PR TITLE
fix wildcard pattern matching for paths with multiple levels

### DIFF
--- a/package/lib/src/beam_location.dart
+++ b/package/lib/src/beam_location.dart
@@ -522,7 +522,7 @@ class RoutesBeamLocation extends BeamLocation<BeamState> {
           path += '/${uriPathSegments[i]}';
 
           if (routePathSegments[i] == '*') {
-            if (i == 0 || i == uriPathSegments.length - 1) {
+            if (i == 0 || i == routePathSegments.length - 1) {
               path = uri.path;
               overrideNotFound = true;
               break;

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -74,7 +74,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
   /// `*App.router` and at least one more [Beamer] in the Widget tree.
   BeamerDelegate? get parent => _parent;
   set parent(BeamerDelegate? parent) {
-    if(parent == null && _parent != null) {
+    if (parent == null && _parent != null) {
       _parent!.removeListener(_updateFromParent);
       _parent!._children.remove(this);
       _parent = null;

--- a/package/test/beam_guard_test.dart
+++ b/package/test/beam_guard_test.dart
@@ -688,7 +688,6 @@ void main() {
           routes: <Pattern, dynamic Function(BuildContext, BeamState, Object?)>{
             '/s1': (_, __, ___) => Container(),
             '/s1/*': (_, __, ___) => Container(),
-            '/s1/s2/s3': (_, __, ___) => Container(),
           },
         ),
         guards: <BeamGuard>[

--- a/package/test/beam_location_test.dart
+++ b/package/test/beam_location_test.dart
@@ -152,31 +152,26 @@ void main() {
         );
       }
 
-      checkMatch('/home', '/home', true);
-      checkMatch('/*', '/home', true);
-      checkMatch('/home/*', '/home/', true);
-      checkMatch('/home/*', '/home/one', true);
-      checkMatch('/home/*', '/home/one/two', true);
+      checkMatch('*', '/', true);
       checkMatch('*', '/home', true);
       checkMatch('*', '/home/one/two', true);
       checkMatch('*', 'pretty much anything', true);
       checkMatch('/*', '/home', true);
-      checkMatch('/*', 'home', true);
       checkMatch('/*', '/home/one/two', true);
-      checkMatch('/*', 'home/one/two', true);
-      checkMatch('/*', '/leading slashes should be ignored', true);
-      checkMatch('/*', 'leading slashed should be ignored', true);
+      checkMatch('/*', '/', true);
+      checkMatch('/home', '/home', true);
+      checkMatch('/home', '/home/', true);
+      checkMatch('/home/*', '/home/one', true);
+      checkMatch('/home/*', '/home/one/two', true);
 
+      checkMatch('*', '', false);
+      checkMatch('/*', '', false);
+      checkMatch('/*', 'home', false);
       checkMatch('/', '/home', false);
-      checkMatch('/home', '/home/', false);
       checkMatch('/home', '/home/one', false);
       checkMatch('/home', '/home/one/two', false);
       checkMatch('/home/*', '/home', false);
-      checkMatch('/home*', '/home/one', false);
-      checkMatch('*', '', false);
-      checkMatch('*', '/', false);
-      checkMatch('/*', '', false);
-      checkMatch('/*', '/', false);
+      checkMatch('/home/*', '/home/', false);
     });
   });
 }

--- a/package/test/beam_location_test.dart
+++ b/package/test/beam_location_test.dart
@@ -135,4 +135,48 @@ void main() {
     delegate.beamToNamed('/');
     expect(delegate.currentBeamLocation, isA<NotFound>());
   });
+
+  group('pattern matching', () {
+    test('pattern matching works correctly when choosing routes', () {
+      void checkMatch(
+        String routeMatcher,
+        String routeToBeMatched,
+        bool shouldMatch,
+      ) {
+        expect(
+          RoutesBeamLocation.chooseRoutes(
+            RouteInformation(location: routeToBeMatched),
+            [routeMatcher],
+          ),
+          shouldMatch ? isNotEmpty : isEmpty,
+        );
+      }
+
+      checkMatch('/home', '/home', true);
+      checkMatch('/*', '/home', true);
+      checkMatch('/home/*', '/home/', true);
+      checkMatch('/home/*', '/home/one', true);
+      checkMatch('/home/*', '/home/one/two', true);
+      checkMatch('*', '/home', true);
+      checkMatch('*', '/home/one/two', true);
+      checkMatch('*', 'pretty much anything', true);
+      checkMatch('/*', '/home', true);
+      checkMatch('/*', 'home', true);
+      checkMatch('/*', '/home/one/two', true);
+      checkMatch('/*', 'home/one/two', true);
+      checkMatch('/*', '/leading slashes should be ignored', true);
+      checkMatch('/*', 'leading slashed should be ignored', true);
+
+      checkMatch('/', '/home', false);
+      checkMatch('/home', '/home/', false);
+      checkMatch('/home', '/home/one', false);
+      checkMatch('/home', '/home/one/two', false);
+      checkMatch('/home/*', '/home', false);
+      checkMatch('/home*', '/home/one', false);
+      checkMatch('*', '', false);
+      checkMatch('*', '/', false);
+      checkMatch('/*', '', false);
+      checkMatch('/*', '/', false);
+    });
+  });
 }

--- a/package/test/beamer_back_button_dispatcher_test.dart
+++ b/package/test/beamer_back_button_dispatcher_test.dart
@@ -170,20 +170,21 @@ void main() {
 
   group('Child dispatcher', () {
     testWidgets('back button pops', (tester) async {
-      final childDelegate = BeamerDelegate(
-        locationBuilder: RoutesLocationBuilder(
-          routes: {
-            '/': (context, state, data) => Container(),
-            '/test': (context, state, data) => Container(),
-          },
-        ),
-      );
+      late BeamerDelegate childDelegate;
       final delegate = BeamerDelegate(
         locationBuilder: RoutesLocationBuilder(
           routes: {
-            '*': (context, state, data) => Beamer(
-                  routerDelegate: childDelegate,
+            '*': (context, state, data) {
+              childDelegate = BeamerDelegate(
+                locationBuilder: RoutesLocationBuilder(
+                  routes: {
+                    '/': (context, state, data) => Container(),
+                    '/test': (context, state, data) => Container(),
+                  },
                 ),
+              );
+              return Beamer(routerDelegate: childDelegate);
+            },
           },
         ),
       );
@@ -216,20 +217,21 @@ void main() {
     });
 
     testWidgets('back button beams back', (tester) async {
-      final childDelegate = BeamerDelegate(
-        locationBuilder: RoutesLocationBuilder(
-          routes: {
-            '/': (context, state, data) => Container(),
-            '/test': (context, state, data) => Container(),
-          },
-        ),
-      );
+      late BeamerDelegate childDelegate;
       final delegate = BeamerDelegate(
         locationBuilder: RoutesLocationBuilder(
           routes: {
-            '*': (context, state, data) => Beamer(
-                  routerDelegate: childDelegate,
+            '*': (context, state, data) {
+              childDelegate = BeamerDelegate(
+                locationBuilder: RoutesLocationBuilder(
+                  routes: {
+                    '/': (context, state, data) => Container(),
+                    '/test': (context, state, data) => Container(),
+                  },
                 ),
+              );
+              return Beamer(routerDelegate: childDelegate);
+            },
           },
         ),
       );
@@ -256,27 +258,30 @@ void main() {
     });
 
     testWidgets('onBack has priority', (tester) async {
-      final childDelegate = BeamerDelegate(
-        locationBuilder: RoutesLocationBuilder(
-          routes: {
-            '/': (context, state, data) => Container(),
-            '/test': (context, state, data) => Container(),
-          },
-        ),
-      );
+      late BeamerDelegate childDelegate;
       late BeamerBackButtonDispatcher rootBackButtonDispatcher;
       final delegate = BeamerDelegate(
         locationBuilder: RoutesLocationBuilder(
           routes: {
-            '*': (context, state, data) => Beamer(
-                  routerDelegate: childDelegate,
-                  backButtonDispatcher: BeamerChildBackButtonDispatcher(
-                    parent: rootBackButtonDispatcher,
-                    delegate: childDelegate,
-                    onBack: (delegate) async =>
-                        true, // do nothing, but say it's handled
-                  ),
+            '*': (context, state, data) {
+              childDelegate = BeamerDelegate(
+                locationBuilder: RoutesLocationBuilder(
+                  routes: {
+                    '/': (context, state, data) => Container(),
+                    '/test': (context, state, data) => Container(),
+                  },
                 ),
+              );
+              return Beamer(
+                routerDelegate: childDelegate,
+                backButtonDispatcher: BeamerChildBackButtonDispatcher(
+                  parent: rootBackButtonDispatcher,
+                  delegate: childDelegate,
+                  onBack: (delegate) async =>
+                      true, // do nothing, but say it's handled
+                ),
+              );
+            },
           },
         ),
       );
@@ -305,26 +310,29 @@ void main() {
     });
 
     testWidgets('inactive child will return false', (tester) async {
-      final childDelegate = BeamerDelegate(
-        locationBuilder: RoutesLocationBuilder(
-          routes: {
-            '/': (context, state, data) => Container(),
-            '/test': (context, state, data) => Container(),
-          },
-        ),
-      );
+      late BeamerDelegate childDelegate;
       late BeamerBackButtonDispatcher rootBackButtonDispatcher;
       final delegate = BeamerDelegate(
         locationBuilder: RoutesLocationBuilder(
           routes: {
-            '*': (context, state, data) => Beamer(
-                  routerDelegate: childDelegate,
-                  backButtonDispatcher: BeamerChildBackButtonDispatcher(
-                    parent: rootBackButtonDispatcher,
-                    delegate: childDelegate,
-                    onBack: (delegate) async => true,
-                  ),
+            '*': (context, state, data) {
+              childDelegate = BeamerDelegate(
+                locationBuilder: RoutesLocationBuilder(
+                  routes: {
+                    '/': (context, state, data) => Container(),
+                    '/test': (context, state, data) => Container(),
+                  },
                 ),
+              );
+              return Beamer(
+                routerDelegate: childDelegate,
+                backButtonDispatcher: BeamerChildBackButtonDispatcher(
+                  parent: rootBackButtonDispatcher,
+                  delegate: childDelegate,
+                  onBack: (delegate) async => true,
+                ),
+              );
+            },
           },
         ),
       );

--- a/package/test/beamer_delegate_test.dart
+++ b/package/test/beamer_delegate_test.dart
@@ -354,18 +354,19 @@ void main() {
           routerDelegate: rootDelegate,
         ),
       );
+      // initial will update history with /
 
-      rootDelegate.beamToNamed('/test'); // initial will update
+      rootDelegate.beamToNamed('/test');
       await tester.pump();
       expect(rootDelegate.configuration.location, '/test');
       expect(childDelegate.configuration.location, '/test');
-      expect(childDelegate.beamingHistory.last.history.length, 1);
+      expect(childDelegate.beamingHistory.last.history.length, 2);
 
       rootDelegate.beamToNamed('/test2');
       await tester.pump();
       expect(rootDelegate.configuration.location, '/test2');
       expect(childDelegate.configuration.location, '/test2');
-      expect(childDelegate.beamingHistory.last.history.length, 2);
+      expect(childDelegate.beamingHistory.last.history.length, 3);
     });
 
     testWidgets("navigation on parent doesn't update nested Beamer",


### PR DESCRIPTION
Original PR: #494 
> The commit https://github.com/slovnicki/beamer/commit/84d582e7acc80483e6303f6d2db3296f77ffc9f1 introduced a bug where the wildcard operator (`*`) would only match paths one level deep. For example `/home/*` would match `/home/single`, but not `home/multiple/levels`.