### PR TITLE
Feature: Route Structure

### DIFF
--- a/package/lib/src/beam_page.dart
+++ b/package/lib/src/beam_page.dart
@@ -82,6 +82,8 @@ class BeamPage extends Page {
     return didStructurePop;
   }
 
+  /// Uses [RouteStructure] Set from [BeamLocation.buildStructure]
+  /// to determine a route that should be popped to.
   static bool? structurePop(
     BuildContext context,
     BeamerDelegate delegate,
@@ -94,13 +96,13 @@ class BeamPage extends Page {
       state.routeInformation.location ?? '/',
     );
     if (result.target != null) {
-      if (result.parent == null) {
+      if (result.stack.isEmpty) {
         return false;
       }
       delegate.removeFirstHistoryElement();
       delegate.update(
         configuration: RouteInformation(
-          location: result.parent!.route.toString(),
+          location: result.stack.last.route.toString(),
         ),
       );
       return true;

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -285,6 +285,8 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
   BeamLocation get currentBeamLocation =>
       beamingHistory.isEmpty ? EmptyBeamLocation() : beamingHistory.last;
 
+  Set<RouteStructure> _currentStructure = {};
+
   List<BeamPage> _currentPages = [];
 
   /// {@template currentPages}
@@ -755,6 +757,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
 
     final navigator = Builder(
       builder: (context) {
+        _setCurrentStructure(context);
         _setCurrentPages(context);
         _setBrowserTitle(context);
 
@@ -951,6 +954,13 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     _updateFromBeamLocationCandidate();
   }
 
+  void _setCurrentStructure(BuildContext context) {
+    _currentStructure = currentBeamLocation.buildStructure(
+      context,
+      currentBeamLocation.state,
+    );
+  }
+
   void _setCurrentPages(BuildContext context) {
     if (currentBeamLocation is NotFound) {
       _currentPages = [notFoundPage];
@@ -976,7 +986,11 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     }
   }
 
-  bool _onPopPage(BuildContext context, Route<dynamic> route, dynamic result) {
+  bool _onPopPage(
+    BuildContext context,
+    Route<dynamic> route,
+    dynamic result,
+  ) {
     if (route.willHandlePopInternally) {
       if (!route.didPop(result)) {
         return false;
@@ -1010,6 +1024,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
         final shouldPop = lastPage.onPopPage(
           context,
           this,
+          _currentStructure,
           currentBeamLocation.state,
           lastPage,
         );

--- a/package/lib/src/location_builders.dart
+++ b/package/lib/src/location_builders.dart
@@ -45,7 +45,10 @@ class RoutesLocationBuilder {
   /// Creates a [RoutesLocationBuilder] with specified properties.
   ///
   /// [routes] are required to build pages from.
-  RoutesLocationBuilder({required this.routes, this.builder});
+  RoutesLocationBuilder({this.structure, required this.routes, this.builder});
+
+  /// A representation of routes structure.
+  final Map<Pattern, dynamic>? structure;
 
   /// List of all routes this builder handles.
   final Map<Pattern, dynamic Function(BuildContext, BeamState, Object?)> routes;
@@ -65,6 +68,7 @@ class RoutesLocationBuilder {
     if (matched.isNotEmpty) {
       return RoutesBeamLocation(
         routeInformation: routeInformation,
+        structure: structure,
         routes: routes,
         navBuilder: builder,
       );

--- a/package/test/beam_location_test.dart
+++ b/package/test/beam_location_test.dart
@@ -272,5 +272,42 @@ void main() {
         expect(delegate.configuration.location, '/');
       },
     );
+
+    testWidgets(
+      'Structure is preferred when stacking pages',
+      (tester) async {
+        final delegate = BeamerDelegate(
+          initialPath: '/route1',
+          locationBuilder: RoutesLocationBuilder(
+            structure: const {
+              '/route1': {
+                '/route2',
+              },
+            },
+            routes: {
+              '/route1': (_, __, ___) => Container(),
+              '/route2': (_, __, ___) => Container(),
+            },
+          ),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp.router(
+            routerDelegate: delegate,
+            routeInformationParser: BeamerParser(),
+          ),
+        );
+
+        delegate.beamToNamed('/route2');
+        await tester.pumpAndSettle();
+        expect(delegate.configuration.location, '/route2');
+        expect(delegate.currentPages.length, 2);
+
+        await delegate.navigator.maybePop();
+        await tester.pumpAndSettle();
+        expect(delegate.configuration.location, '/route1');
+        expect(delegate.currentPages.length, 1);
+      },
+    );
   });
 }

--- a/package/test/beam_location_test.dart
+++ b/package/test/beam_location_test.dart
@@ -212,4 +212,65 @@ void main() {
       verify(() => updateStateStub.call()).called(1);
     });
   });
+
+  group('Route Structure', () {
+    testWidgets(
+      'Structure is used for pops in custom BeamLocation',
+      (tester) async {
+        final delegate = BeamerDelegate(
+          locationBuilder: BeamerLocationBuilder(
+            beamLocations: [BeamLocationWithStructure()],
+          ),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp.router(
+            routerDelegate: delegate,
+            routeInformationParser: BeamerParser(),
+          ),
+        );
+
+        delegate.beamToNamed('/some/thing/deeper');
+        await tester.pumpAndSettle();
+        expect(delegate.configuration.location, '/some/thing/deeper');
+
+        await delegate.navigator.maybePop();
+        await tester.pumpAndSettle();
+        expect(delegate.configuration.location, '/');
+      },
+    );
+    testWidgets(
+      'Structure is used for pops in RoutesBeamLocation',
+      (tester) async {
+        final delegate = BeamerDelegate(
+          locationBuilder: RoutesLocationBuilder(
+            structure: const {
+              '/': {
+                '/some/thing/deeper',
+              },
+            },
+            routes: {
+              '/': (_, __, ___) => Container(),
+              '/some/thing/deeper': (_, __, ___) => Container(),
+            },
+          ),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp.router(
+            routerDelegate: delegate,
+            routeInformationParser: BeamerParser(),
+          ),
+        );
+
+        delegate.beamToNamed('/some/thing/deeper');
+        await tester.pumpAndSettle();
+        expect(delegate.configuration.location, '/some/thing/deeper');
+
+        await delegate.navigator.maybePop();
+        await tester.pumpAndSettle();
+        expect(delegate.configuration.location, '/');
+      },
+    );
+  });
 }

--- a/package/test/beam_page_test.dart
+++ b/package/test/beam_page_test.dart
@@ -17,7 +17,7 @@ class TestLocation extends BeamLocation<BeamState> {
         if (state.pathPatternSegments.contains('books'))
           BeamPage(
             key: const ValueKey('books'),
-            onPopPage: (context, delegate, _, page) {
+            onPopPage: (context, delegate, _, __, page) {
               return false;
             },
             child: Container(),
@@ -31,7 +31,7 @@ class TestLocation extends BeamLocation<BeamState> {
         if (state.pathPatternSegments.contains('details'))
           BeamPage(
             key: ValueKey('book-${state.pathParameters['bookId']}-details'),
-            onPopPage: (context, delegate, _, page) {
+            onPopPage: (context, delegate, _, __, page) {
               delegate.currentBeamLocation.update(
                 (state) => (state as BeamState).copyWith(
                   pathPatternSegments: ['books'],

--- a/package/test/test_locations.dart
+++ b/package/test/test_locations.dart
@@ -177,3 +177,38 @@ class UpdateStateStubBeamLocation extends BeamLocation {
     updateStateStub.call();
   }
 }
+
+class BeamLocationWithStructure extends BeamLocation<BeamState> {
+  @override
+  bool get strictPathPatterns => true;
+
+  @override
+  List<Pattern> get pathPatterns => ['/', '/some/thing/deeper'];
+
+  @override
+  Set<RouteStructure> buildStructure(BuildContext context, BeamState state) {
+    return const {
+      RouteStructure(
+        '/',
+        {
+          RouteStructure('/some/thing/deeper'),
+        },
+      ),
+    };
+  }
+
+  @override
+  List<BeamPage> buildPages(BuildContext context, BeamState state) {
+    return [
+      BeamPage(
+        key: const ValueKey('home'),
+        child: Container(),
+      ),
+      if (state.pathPatternSegments.length == 3)
+        BeamPage(
+          key: const ValueKey('something-deeper'),
+          child: Container(),
+        ),
+    ];
+  }
+}


### PR DESCRIPTION
This should
- Solve an unintuitive problem of how to handle popping from e.g. `/some/thing/deeper` to `/` if these 2 really are the only pages in the stack
- Enable implementing complex popping logic and routing structure more naturally than it is currently handled
- Enable having custom page stacking strategies even with `RoutesLocationBuilder`

A good example that demonstrates the new feature is this test:
```dart
testWidgets(
  'Structure is used for pops in RoutesBeamLocation',
  (tester) async {
    final delegate = BeamerDelegate(
      locationBuilder: RoutesLocationBuilder(
        structure: const {
          '/': {
            '/some/thing/deeper',
          },
        },
        routes: {
          '/': (_, __, ___) => Container(),
          '/some/thing/deeper': (_, __, ___) => Container(),
        },
      ),
    );

    await tester.pumpWidget(
      MaterialApp.router(
        routerDelegate: delegate,
        routeInformationParser: BeamerParser(),
      ),
    );

    delegate.beamToNamed('/some/thing/deeper');
    await tester.pumpAndSettle();
    expect(delegate.configuration.location, '/some/thing/deeper');

    await delegate.navigator.maybePop();
    await tester.pumpAndSettle();
    expect(delegate.configuration.location, '/');
  },
);
```