### PR TITLE
Fix: rebuild nested beamer delegate upon opening by deeplink

### DIFF
--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -1065,7 +1065,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     if (beamLocation is! NotFound) {
       update(
         configuration: parentConfiguration,
-        rebuild: false,
+        rebuild: rebuild,
         updateParent: false,
         updateRouteInformation: false,
       );

--- a/package/test/beamer_delegate_test.dart
+++ b/package/test/beamer_delegate_test.dart
@@ -365,9 +365,9 @@ void main() {
       final childDelegate = BeamerDelegate(
         locationBuilder: RoutesLocationBuilder(
           routes: {
-            '/': (context, state, data) => Container(),
-            '/test': (context, state, data) => Container(),
-            '/test2': (context, state, data) => Container(),
+            '/': (context, state, data) => const Text('/'),
+            '/test': (context, state, data) => const Text('/test'),
+            '/test2': (context, state, data) => const Text('/test2'),
           },
         ),
       );
@@ -393,12 +393,14 @@ void main() {
 
       rootDelegate.beamToNamed('/test');
       await tester.pump();
+      expect(find.text('/test'), findsOneWidget);
       expect(rootDelegate.configuration.location, '/test');
       expect(childDelegate.configuration.location, '/test');
       expect(childDelegate.beamingHistory.last.history.length, 2);
 
       rootDelegate.beamToNamed('/test2');
       await tester.pump();
+      expect(find.text('/test2'), findsOneWidget);
       expect(rootDelegate.configuration.location, '/test2');
       expect(childDelegate.configuration.location, '/test2');
       expect(childDelegate.beamingHistory.last.history.length, 3);


### PR DESCRIPTION
fix issue #555 