### PR TITLE
Fix beam parameter history 1-off from current

### DIFF
--- a/package/lib/src/location_builders.dart
+++ b/package/lib/src/location_builders.dart
@@ -33,6 +33,7 @@ class BeamerLocationBuilder {
       Uri.parse(routeInformation.location ?? '/'),
       beamLocations,
       routeState: routeInformation.state,
+      beamParameters: beamParameters,
     );
   }
 }

--- a/package/lib/src/utils.dart
+++ b/package/lib/src/utils.dart
@@ -27,7 +27,7 @@ abstract class Utils {
         if (!beamLocation.isCurrent) {
           beamLocation.create(routeInformation, beamParameters);
         } else {
-          beamLocation.update(null, routeInformation, null, false);
+          beamLocation.update(null, routeInformation, beamParameters, false);
         }
         return beamLocation;
       }

--- a/package/lib/src/utils.dart
+++ b/package/lib/src/utils.dart
@@ -16,6 +16,7 @@ abstract class Utils {
     List<BeamLocation> beamLocations, {
     Object? data,
     Object? routeState,
+    BeamParameters? beamParameters,
   }) {
     for (final beamLocation in beamLocations) {
       if (canBeamLocationHandleUri(beamLocation, uri)) {
@@ -24,7 +25,7 @@ abstract class Utils {
           state: routeState,
         );
         if (!beamLocation.isCurrent) {
-          beamLocation.create(routeInformation);
+          beamLocation.create(routeInformation, beamParameters);
         } else {
           beamLocation.update(null, routeInformation, null, false);
         }


### PR DESCRIPTION
Historic beam parameters are always one spot off from their routes. This fixes that discrepancy, and with it `BeamDelegate.currentBeamLocation.beamParameters`.

See: https://github.com/slovnicki/beamer/issues/561