### PR TITLE
Fix: logout behaviour in authentication_bloc example demo

### DIFF
--- a/examples/authentication_bloc/lib/bloc/authentication_bloc.dart
+++ b/examples/authentication_bloc/lib/bloc/authentication_bloc.dart
@@ -40,8 +40,7 @@ class AuthenticationBloc
 
   bool isAuthenticated() => state.status == AuthenticationStatus.authenticated;
 
-  void logout() =>
-      add(AuthenticationStatusChanged(AuthenticationStatus.unauthenticated));
+  void logout() => add(AuthenticationLogoutRequested());
 
   @override
   Future<void> close() {


### PR DESCRIPTION
A small fix for the logout behaviour in the example with authentication.

instead of using `AuthenticationStatusChanged` directly, we should trigger the `_authenticationRepository.logOut` and listen for the incoming `AuthenticationStatusChanged`.