### PR TITLE
Fix regexp path patern's not all checked

### DIFF
--- a/package/lib/src/beam_guard.dart
+++ b/package/lib/src/beam_guard.dart
@@ -211,7 +211,13 @@ class BeamGuard {
         }
       } else {
         final regexp = Utils.tryCastToRegExp(pathPattern);
-        return regexp.hasMatch(path);
+        final result = regexp.hasMatch(path);
+
+        if (result) {
+          return true;
+        } else {
+          continue;
+        }
       }
     }
     return false;

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -360,6 +360,8 @@ abstract class BeamStack<T extends RouteInformationSerializable>
   /// If this is false (default), then a path pattern '/some/path' will match
   /// '/' and '/some' and '/some/path'.
   /// If this is true, then it will match just '/some/path'.
+  /// 
+  /// __This only applies if the pattern is of type STRING, not REGEXP__
   bool get strictPathPatterns => false;
 
   /// Creates and returns the list of pages to be built by the [Navigator]

--- a/package/lib/src/utils.dart
+++ b/package/lib/src/utils.dart
@@ -99,7 +99,13 @@ abstract class Utils {
         }
       } else {
         final regexp = tryCastToRegExp(pathPattern);
-        return regexp.hasMatch(uri.toString());
+        final result = regexp.hasMatch(uri.toString());
+
+        if (result) {
+          return true;
+        } else {
+          continue;
+        }
       }
     }
     return false;


### PR DESCRIPTION
## Summary
**Issue:** Regular expression (regexp) path patterns are not being fully checked during the path pattern matching process.

## Detailed Description
I encountered this issue while working with path pattern matching. The core problem lies in the handling of regular expression (regexp) path patterns within the codebase. Specifically, the current implementation fails to iterate over all provided path patterns, stopping the process prematurely when it encounters a failure. This limitation significantly restricts the utility and flexibility of using regular expressions for path matching.

## Solution
The proposed fix ensures that all path patterns are checked by modifying the iteration logic. Instead of returning upon the first failure, the code now continues to iterate through the entire list of path patterns, thereby improving the robustness and reliability of the regexp path pattern matching.

By applying this fix, the system will be able to handle a more extensive range of path patterns, thus enhancing its functionality and accommodating more complex use cases.