### PR TITLE
Removed transition and reverese transition durations on BeamPage

### DIFF
--- a/package/lib/src/beam_page.dart
+++ b/package/lib/src/beam_page.dart
@@ -323,6 +323,8 @@ class BeamPage extends Page {
           opaque: opaque,
           settings: this,
           pageBuilder: (context, animation, secondaryAnimation) => child,
+          transitionDuration: Duration.zero,
+          reverseTransitionDuration: Duration.zero,
         );
       default:
         return MaterialPageRoute(


### PR DESCRIPTION
When BeamPage is BeamPageType.noTransition