### PR TITLE
Notifiers feature

### DIFF
--- a/package/lib/src/beam_page.dart
+++ b/package/lib/src/beam_page.dart
@@ -37,7 +37,7 @@ enum BeamPageType {
 }
 
 /// A wrapper for screens in a navigation stack.
-class BeamPage extends Page {
+class BeamPage<T extends BeamPageInfo> extends Page {
   /// Creates a [BeamPage] with specified properties.
   ///
   /// [child] is required and typically represents a screen of the app.
@@ -56,6 +56,7 @@ class BeamPage extends Page {
     this.opaque = true,
     this.keepQueryOnPop = false,
     this.stateChangeNotifier,
+    this.info,
   }) : super(key: key, name: name);
 
   /// A [BeamPage] to be the default for [BeamerDelegate.notFoundPage].
@@ -236,6 +237,8 @@ class BeamPage extends Page {
 
   final BeamPageStateNotifier? stateChangeNotifier;
 
+  final T? info;
+
   @override
   Route createRoute(BuildContext context) {
     if (routeBuilder != null) {
@@ -371,4 +374,20 @@ class BeamPageStateNotifier extends ValueListenable<BeamPageState>
 
   @override
   late BeamPageState value;
+}
+
+/// Represents specific page related information.
+///
+/// Not represents state.
+mixin class BeamPageInfo {
+  const BeamPageInfo();
+}
+
+/// Utility to inform the current [BeamPageInfo] of [BeamerDelegate].
+class BeamPageInfoNotifier<T extends BeamPageInfo> extends ValueListenable<T?>
+    with ChangeNotifier {
+  BeamPageInfoNotifier();
+
+  @override
+  late T? value;
 }

--- a/package/lib/src/beam_page.dart
+++ b/package/lib/src/beam_page.dart
@@ -374,6 +374,15 @@ class BeamPageStateNotifier extends ValueListenable<BeamPageState>
 
   @override
   late BeamPageState value;
+
+  @override
+  void notifyListeners({bool ignore = false}) {
+    if (ignore) {
+      return;
+    }
+
+    super.notifyListeners();
+  }
 }
 
 /// Represents specific page related information.

--- a/package/lib/src/beam_page.dart
+++ b/package/lib/src/beam_page.dart
@@ -55,6 +55,7 @@ class BeamPage extends Page {
     this.fullScreenDialog = false,
     this.opaque = true,
     this.keepQueryOnPop = false,
+    this.stateChangeNotifier,
   }) : super(key: key, name: name);
 
   /// A [BeamPage] to be the default for [BeamerDelegate.notFoundPage].
@@ -233,6 +234,8 @@ class BeamPage extends Page {
 
   LocalKey get key => super.key!;
 
+  final BeamPageStateNotifier? stateChangeNotifier;
+
   @override
   Route createRoute(BuildContext context) {
     if (routeBuilder != null) {
@@ -361,47 +364,46 @@ class BeamPageState {
   int get hashCode => isPinnacle.hashCode;
 }
 
-/// Utility to inform [BeamPageState] to his [BeamPage].
-class BeamPageNotifier extends ValueListenable<BeamPageState> {
-  BeamPageNotifier(
-    this.value, {
-    required this.parentStackDebugLabel,
-  }) {
-    print('BeamPageNotifier.constructor() -- $_debugLabel');
-  }
+// class BeamPageNotifier extends ValueListenable<BeamPageState> {
+//   BeamPageNotifier(
+//     this.value, {
+//     required this.parentStackDebugLabel,
+//   }) {
+//     print('BeamPageNotifier.constructor() -- $_debugLabel');
+//   }
 
-  final String parentStackDebugLabel;
-  final _debugLabel = DateTime.now().millisecondsSinceEpoch.toString();
+//   final String parentStackDebugLabel;
+//   final _debugLabel = DateTime.now().millisecondsSinceEpoch.toString();
 
-  final _listeners = <VoidCallback>{};
+//   final _listeners = <VoidCallback>{};
 
-  BeamPageState value;
+//   BeamPageState value;
 
-  String get fullDebugLabel => '$parentStackDebugLabel-$_debugLabel';
+//   String get fullDebugLabel => '$parentStackDebugLabel-$_debugLabel';
 
-  @override
-  void addListener(VoidCallback listener) {
-    _listeners.add(listener);
-    print(
-        'BeamPageNotifier.addListener() -- $_debugLabel -- Count: ${_listeners.length}');
-  }
+//   @override
+//   void addListener(VoidCallback listener) {
+//     _listeners.add(listener);
+//     print(
+//         'BeamPageNotifier.addListener() -- $_debugLabel -- Count: ${_listeners.length}');
+//   }
 
-  @override
-  void removeListener(VoidCallback listener) {
-    _listeners.remove(listener);
-    print(
-        'BeamPageNotifier.removeListener() -- $_debugLabel -- Count: ${_listeners.length}');
-  }
+//   @override
+//   void removeListener(VoidCallback listener) {
+//     _listeners.remove(listener);
+//     print(
+//         'BeamPageNotifier.removeListener() -- $_debugLabel -- Count: ${_listeners.length}');
+//   }
 
-  void notify() {
-    for (final listener in _listeners) {
-      listener();
-    }
+//   void notify() {
+//     for (final listener in _listeners) {
+//       listener();
+//     }
 
-    print(
-        'BeamPageNotifier.notify() -- $_debugLabel -- Count: ${_listeners.length}');
-  }
-}
+//     print(
+//         'BeamPageNotifier.notify() -- $_debugLabel -- Count: ${_listeners.length}');
+//   }
+// }
 
 /// Utility to get a [BeamPageNotifier].
 ///
@@ -409,20 +411,21 @@ class BeamPageNotifier extends ValueListenable<BeamPageState> {
 /// the page is created.
 // typedef BeamPageNotifierReference = BeamPageNotifier Function(LocalKey);
 // typedef BeamPageNotifierReference = BeamPageNotifier Function();
-class BeamPageNotifierReference {
-  BeamPageNotifierReference();
+// class BeamPageNotifierReference {
+//   BeamPageNotifierReference();
 
-  BeamPageNotifier? _notifier;
+//   BeamPageNotifier? _notifier;
 
-  late final BeamPageNotifier Function() getNotifier;
+//   late final BeamPageNotifier Function() getNotifier;
 
-  BeamPageNotifier get notifier => _notifier ??= getNotifier();
-}
+//   BeamPageNotifier get notifier => _notifier ??= getNotifier();
+// }
 
-class BeamPageStateChangeNotifier extends ValueListenable<BeamPageState>
+/// Utility to inform [BeamPageState] to his [BeamPage].
+class BeamPageStateNotifier extends ValueListenable<BeamPageState>
     with ChangeNotifier {
-  BeamPageStateChangeNotifier(this.value);
+  BeamPageStateNotifier();
 
   @override
-  BeamPageState value;
+  late BeamPageState value;
 }

--- a/package/lib/src/beam_page.dart
+++ b/package/lib/src/beam_page.dart
@@ -363,15 +363,21 @@ class BeamPageState {
 
 /// Utility to inform [BeamPageState] to his [BeamPage].
 class BeamPageNotifier extends ValueListenable<BeamPageState> {
-  BeamPageNotifier(this.value) {
+  BeamPageNotifier(
+    this.value, {
+    required this.parentStackDebugLabel,
+  }) {
     print('BeamPageNotifier.constructor() -- $_debugLabel');
   }
 
+  final String parentStackDebugLabel;
   final _debugLabel = DateTime.now().millisecondsSinceEpoch.toString();
 
   final _listeners = <VoidCallback>{};
 
   BeamPageState value;
+
+  String get fullDebugLabel => '$parentStackDebugLabel-$_debugLabel';
 
   @override
   void addListener(VoidCallback listener) {

--- a/package/lib/src/beam_page.dart
+++ b/package/lib/src/beam_page.dart
@@ -364,63 +364,6 @@ class BeamPageState {
   int get hashCode => isPinnacle.hashCode;
 }
 
-// class BeamPageNotifier extends ValueListenable<BeamPageState> {
-//   BeamPageNotifier(
-//     this.value, {
-//     required this.parentStackDebugLabel,
-//   }) {
-//     print('BeamPageNotifier.constructor() -- $_debugLabel');
-//   }
-
-//   final String parentStackDebugLabel;
-//   final _debugLabel = DateTime.now().millisecondsSinceEpoch.toString();
-
-//   final _listeners = <VoidCallback>{};
-
-//   BeamPageState value;
-
-//   String get fullDebugLabel => '$parentStackDebugLabel-$_debugLabel';
-
-//   @override
-//   void addListener(VoidCallback listener) {
-//     _listeners.add(listener);
-//     print(
-//         'BeamPageNotifier.addListener() -- $_debugLabel -- Count: ${_listeners.length}');
-//   }
-
-//   @override
-//   void removeListener(VoidCallback listener) {
-//     _listeners.remove(listener);
-//     print(
-//         'BeamPageNotifier.removeListener() -- $_debugLabel -- Count: ${_listeners.length}');
-//   }
-
-//   void notify() {
-//     for (final listener in _listeners) {
-//       listener();
-//     }
-
-//     print(
-//         'BeamPageNotifier.notify() -- $_debugLabel -- Count: ${_listeners.length}');
-//   }
-// }
-
-/// Utility to get a [BeamPageNotifier].
-///
-/// Needed because [BeamPage] is const and the notifier is not known until
-/// the page is created.
-// typedef BeamPageNotifierReference = BeamPageNotifier Function(LocalKey);
-// typedef BeamPageNotifierReference = BeamPageNotifier Function();
-// class BeamPageNotifierReference {
-//   BeamPageNotifierReference();
-
-//   BeamPageNotifier? _notifier;
-
-//   late final BeamPageNotifier Function() getNotifier;
-
-//   BeamPageNotifier get notifier => _notifier ??= getNotifier();
-// }
-
 /// Utility to inform [BeamPageState] to his [BeamPage].
 class BeamPageStateNotifier extends ValueListenable<BeamPageState>
     with ChangeNotifier {

--- a/package/lib/src/beam_page.dart
+++ b/package/lib/src/beam_page.dart
@@ -1,6 +1,7 @@
 import 'package:beamer/beamer.dart';
 import 'package:beamer/src/utils.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// Types for how to route should be built.
@@ -230,6 +231,8 @@ class BeamPage extends Page {
   /// Defaults to `false`.
   final bool keepQueryOnPop;
 
+  LocalKey get key => super.key!;
+
   @override
   Route createRoute(BuildContext context) {
     if (routeBuilder != null) {
@@ -334,4 +337,78 @@ class BeamPage extends Page {
         );
     }
   }
+}
+
+/// Represents the [BeamPage] state inside a [BeamStack].
+///
+/// This is a volatile state, meaning it is not stored. On the contrary, it is
+/// regenerated on [BeamerDelegate.build].
+///
+/// Initialy created to inform a page whether is the last (the pinnacle)
+/// on the stack.
+class BeamPageState {
+  BeamPageState({
+    required this.isPinnacle,
+  });
+
+  final bool isPinnacle;
+
+  @override
+  bool operator ==(Object other) =>
+      other is BeamPageState && isPinnacle == other.isPinnacle;
+
+  @override
+  int get hashCode => isPinnacle.hashCode;
+}
+
+/// Utility to inform [BeamPageState] to his [BeamPage].
+class BeamPageNotifier extends ValueListenable<BeamPageState> {
+  BeamPageNotifier(this.value) {
+    print('BeamPageNotifier.constructor() -- $_debugLabel');
+  }
+
+  final _debugLabel = DateTime.now().millisecondsSinceEpoch.toString();
+
+  final _listeners = <VoidCallback>{};
+
+  BeamPageState value;
+
+  @override
+  void addListener(VoidCallback listener) {
+    _listeners.add(listener);
+    print(
+        'BeamPageNotifier.addListener() -- $_debugLabel -- Count: ${_listeners.length}');
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    _listeners.remove(listener);
+    print(
+        'BeamPageNotifier.removeListener() -- $_debugLabel -- Count: ${_listeners.length}');
+  }
+
+  void notify() {
+    for (final listener in _listeners) {
+      listener();
+    }
+
+    print(
+        'BeamPageNotifier.notify() -- $_debugLabel -- Count: ${_listeners.length}');
+  }
+}
+
+/// Utility to get a [BeamPageNotifier].
+///
+/// Needed because [BeamPage] is const and the notifier is not known until
+/// the page is created.
+// typedef BeamPageNotifierReference = BeamPageNotifier Function(LocalKey);
+// typedef BeamPageNotifierReference = BeamPageNotifier Function();
+class BeamPageNotifierReference {
+  BeamPageNotifierReference();
+
+  BeamPageNotifier? _notifier;
+
+  late final BeamPageNotifier Function() getNotifier;
+
+  BeamPageNotifier get notifier => _notifier ??= getNotifier();
 }

--- a/package/lib/src/beam_page.dart
+++ b/package/lib/src/beam_page.dart
@@ -418,3 +418,11 @@ class BeamPageNotifierReference {
 
   BeamPageNotifier get notifier => _notifier ??= getNotifier();
 }
+
+class BeamPageStateChangeNotifier extends ValueListenable<BeamPageState>
+    with ChangeNotifier {
+  BeamPageStateChangeNotifier(this.value);
+
+  @override
+  BeamPageState value;
+}

--- a/package/lib/src/beam_page.dart
+++ b/package/lib/src/beam_page.dart
@@ -323,6 +323,8 @@ class BeamPage extends Page {
           opaque: opaque,
           settings: this,
           pageBuilder: (context, animation, secondaryAnimation) => child,
+          transitionDuration: Duration.zero,
+          reverseTransitionDuration: Duration.zero,
         );
       default:
         return MaterialPageRoute(

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -95,6 +95,8 @@ abstract class BeamStack<T extends RouteInformationSerializable>
     create(routeInformation, beamParameters);
   }
 
+  final debugLabel = DateTime.now().millisecondsSinceEpoch.toString();
+
   late T _state;
 
   /// A state of this [BeamStack].
@@ -473,6 +475,7 @@ class RoutesBeamStack extends BeamStack<BeamState> {
   /// we can't know the [BeamPage.key] before creating them (see [buildPages]).
   final Map<LocalKey, BeamPageNotifier> _pageNotifiers = {};
   // final List<BeamPageNotifier> _pageNotifiers = [];
+  // final Map<ValueKey, BeamPageNotifier> _pageNotifiers = {};
 
   @override
   Widget builder(BuildContext context, Widget navigator) {
@@ -500,6 +503,8 @@ class RoutesBeamStack extends BeamStack<BeamState> {
 
   @override
   List<BeamPage> buildPages(BuildContext context, BeamState state) {
+    _printCurrentPageNotifiers('buildPages');
+
     final filteredRoutes = chooseRoutes(state.routeInformation, routes.keys);
     final routeBuilders = Map.of(routes)
       ..removeWhere((key, value) => !filteredRoutes.containsKey(key));
@@ -519,7 +524,9 @@ class RoutesBeamStack extends BeamStack<BeamState> {
             );
       print('Notifier exists: ${_pageNotifiers.containsKey(page.key)}');
       final notifier = _pageNotifiers[page.key] ??= BeamPageNotifier(
-          BeamPageState(isPinnacle: index == sortedRoutes.length - 1));
+        BeamPageState(isPinnacle: index == sortedRoutes.length - 1),
+        parentStackDebugLabel: debugLabel,
+      );
       notifierReference.getNotifier = () => notifier;
       return page;
     }).toList();
@@ -623,6 +630,8 @@ class RoutesBeamStack extends BeamStack<BeamState> {
   }
 
   void notifyPages(List<BeamPage> pages) {
+    _printCurrentPageNotifiers('notifyPages');
+
     // Hidden pages
     for (int i = 0; i < pages.length - 1; i++) {
       print('Notifying page: ${pages[i].title} -- Is pinnacle: false');
@@ -644,5 +653,12 @@ class RoutesBeamStack extends BeamStack<BeamState> {
     // final notifiers = [..._pageNotifiers.values];
     // _pageNotifiers.clear();
     // return notifiers;
+  }
+
+  void _printCurrentPageNotifiers(String debugLabel) {
+    print('_printCurrentPageNotifiers() -- ${this.debugLabel} -- $debugLabel');
+    for (final entry in _pageNotifiers.entries) {
+      print('LocalKey: ${entry.key}, Notifier: ${entry.value.fullDebugLabel}');
+    }
   }
 }

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -494,7 +494,7 @@ class RoutesBeamStack<T extends BeamPageInfo> extends BeamStack<BeamState, T> {
     final sortedRoutes = routeBuilders.keys.toList()
       ..sort((a, b) => _compareKeys(a, b));
     final pages = sortedRoutes.indexed.map<BeamPage<T>>((value) {
-      final index = value.$1;
+      // final index = value.$1;
       final route = value.$2;
       final routeElement = routes[route]!(context, state, data);
       final BeamPage<T> page = routeElement is BeamPage
@@ -504,11 +504,10 @@ class RoutesBeamStack<T extends BeamPageInfo> extends BeamStack<BeamState, T> {
               child: routeElement,
             );
 
-      // Initializing page state
+      // Storing page state notifier
       final stateChangeNotifier = page.stateChangeNotifier;
       if (stateChangeNotifier != null) {
-        parent.pageNotifiers[page.key] = stateChangeNotifier
-          ..value = BeamPageState(isPinnacle: index == sortedRoutes.length - 1);
+        parent.pageStateNotifiers[page.key] = stateChangeNotifier;
       }
 
       return page;

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -453,6 +453,7 @@ class RoutesBeamStack extends BeamStack<BeamState> {
   ///
   /// [routeInformation] and [routes] are required.
   RoutesBeamStack({
+    required this.parent,
     required String debugLabel,
     required String creationReason,
     required RouteInformation routeInformation,
@@ -461,8 +462,10 @@ class RoutesBeamStack extends BeamStack<BeamState> {
     required this.routes,
     this.navBuilder,
   }) : super(debugLabel, routeInformation, beamParameters) {
-    print('RoutesBeamStack.constructor() -- $debugLabel -- $creationReason');
+    // print('RoutesBeamStack.constructor() -- $debugLabel -- $creationReason');
   }
+
+  final BeamerDelegate parent;
 
   /// Map of all routes this stack handles.
   final Map<
@@ -483,7 +486,7 @@ class RoutesBeamStack extends BeamStack<BeamState> {
   ///
   /// The reason for not making them persistent across build cycles is that
   /// we can't know the [BeamPage.key] before creating them (see [buildPages]).
-  final Map<LocalKey, BeamPageNotifier> _pageNotifiers = {};
+  // final Map<LocalKey, BeamPageNotifier> _pageNotifiers = {};
   // final List<BeamPageNotifier> _pageNotifiers = [];
   // final Map<ValueKey, BeamPageNotifier> _pageNotifiers = {};
 
@@ -532,8 +535,8 @@ class RoutesBeamStack extends BeamStack<BeamState> {
               key: ValueKey(filteredRoutes[route]),
               child: routeElement,
             );
-      print('Notifier exists: ${_pageNotifiers.containsKey(page.key)}');
-      final notifier = _pageNotifiers[page.key] ??= BeamPageNotifier(
+      print('Notifier exists: ${parent.pageNotifiers.containsKey(page.key)}');
+      final notifier = parent.pageNotifiers[page.key] ??= BeamPageNotifier(
         BeamPageState(isPinnacle: index == sortedRoutes.length - 1),
         parentStackDebugLabel: debugLabel,
       );
@@ -645,21 +648,21 @@ class RoutesBeamStack extends BeamStack<BeamState> {
     // Hidden pages
     for (int i = 0; i < pages.length - 1; i++) {
       print('Notifying page: ${pages[i].title} -- Is pinnacle: false');
-      _pageNotifiers[pages[i].key]!
+      parent.pageNotifiers[pages[i].key]!
         ..value = BeamPageState(isPinnacle: false)
         ..notify();
     }
 
     // Pinnacle page
     print('Notifying page: ${pages.last.title} -- Is pinnacle: true');
-    _pageNotifiers[pages.last.key]!
+    parent.pageNotifiers[pages.last.key]!
       ..value = BeamPageState(isPinnacle: true)
       ..notify();
   }
 
   /// Returns current notifiers and clean them up.
   List<BeamPageNotifier> getPageNotifiers() {
-    return [..._pageNotifiers.values];
+    return [...parent.pageNotifiers.values];
     // final notifiers = [..._pageNotifiers.values];
     // _pageNotifiers.clear();
     // return notifiers;

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -516,8 +516,6 @@ class RoutesBeamStack extends BeamStack<BeamState> {
 
   @override
   List<BeamPage> buildPages(BuildContext context, BeamState state) {
-    // _printCurrentPageNotifiers('buildPages');
-
     final filteredRoutes = chooseRoutes(state.routeInformation, routes.keys);
     final routeBuilders = Map.of(routes)
       ..removeWhere((key, value) => !filteredRoutes.containsKey(key));
@@ -641,37 +639,4 @@ class RoutesBeamStack extends BeamStack<BeamState> {
 
     return isNotFound ? {} : matched;
   }
-
-  void notifyPages(List<BeamPage> pages) {
-    // _printCurrentPageNotifiers('notifyPages');
-
-    // Hidden pages
-    for (int i = 0; i < pages.length - 1; i++) {
-      print('Notifying page: ${pages[i].title} -- Is pinnacle: false');
-      parent.pageNotifiers[pages[i].key]!
-        ..value = BeamPageState(isPinnacle: false)
-        ..notify();
-    }
-
-    // Pinnacle page
-    print('Notifying page: ${pages.last.title} -- Is pinnacle: true');
-    parent.pageNotifiers[pages.last.key]!
-      ..value = BeamPageState(isPinnacle: true)
-      ..notify();
-  }
-
-  /// Returns current notifiers and clean them up.
-  List<BeamPageNotifier> getPageNotifiers() {
-    return [...parent.pageNotifiers.values];
-    // final notifiers = [..._pageNotifiers.values];
-    // _pageNotifiers.clear();
-    // return notifiers;
-  }
-
-  // void _printCurrentPageNotifiers(String debugLabel) {
-  //   print('_printCurrentPageNotifiers() -- ${this.debugLabel} -- $debugLabel');
-  //   for (final entry in _pageNotifiers.entries) {
-  //     print('LocalKey: ${entry.key}, Notifier: ${entry.value.fullDebugLabel}');
-  //   }
-  // }
 }

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -541,6 +541,7 @@ class RoutesBeamStack extends BeamStack<BeamState> {
       notifierReference.getNotifier = () => notifier;
       return page;
     }).toList();
+
     return pages;
   }
 

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -446,7 +446,6 @@ class RoutesBeamStack extends BeamStack<BeamState> {
   /// [routeInformation] and [routes] are required.
   RoutesBeamStack({
     required this.parent,
-    required String creationReason,
     required RouteInformation routeInformation,
     Object? data,
     BeamParameters? beamParameters,

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -88,17 +88,12 @@ abstract class BeamStack<T extends RouteInformationSerializable>
   /// Creates a [BeamStack] with specified properties.
   ///
   /// All attributes can be null.
-  BeamStack(
-    this.debugLabel, [
+  BeamStack([
     RouteInformation? routeInformation,
     BeamParameters? beamParameters,
   ]) {
     create(routeInformation, beamParameters);
   }
-
-  // final debugLabel = DateTime.now().millisecondsSinceEpoch.toString();
-
-  final String debugLabel;
 
   late T _state;
 
@@ -399,8 +394,7 @@ abstract class BeamStack<T extends RouteInformationSerializable>
 class NotFound extends BeamStack<BeamState> {
   /// Creates a [NotFound] [BeamStack] with
   /// `RouteInformation(uri: Uri.parse(path)` as its state.
-  NotFound({String path = '/'})
-      : super('NotFound', RouteInformation(uri: Uri.parse(path)));
+  NotFound({String path = '/'}) : super(RouteInformation(uri: Uri.parse(path)));
 
   @override
   List<BeamPage> buildPages(BuildContext context, BeamState state) => [];
@@ -413,8 +407,6 @@ class NotFound extends BeamStack<BeamState> {
 ///
 /// See [BeamerDelegate.currentBeamStack].
 class EmptyBeamStack extends BeamStack<BeamState> {
-  EmptyBeamStack() : super('EmptyBeamStack');
-
   @override
   List<BeamPage> buildPages(BuildContext context, BeamState state) => [];
 
@@ -429,7 +421,7 @@ class GuardShowPage extends BeamStack<BeamState> {
   GuardShowPage(
     this.routeInformation,
     this.beamPage,
-  ) : super('GuardShowPage', routeInformation);
+  ) : super(routeInformation);
 
   /// [RouteInformation] to show in URL
   final RouteInformation routeInformation;
@@ -454,16 +446,13 @@ class RoutesBeamStack extends BeamStack<BeamState> {
   /// [routeInformation] and [routes] are required.
   RoutesBeamStack({
     required this.parent,
-    required String debugLabel,
     required String creationReason,
     required RouteInformation routeInformation,
     Object? data,
     BeamParameters? beamParameters,
     required this.routes,
     this.navBuilder,
-  }) : super(debugLabel, routeInformation, beamParameters) {
-    // print('RoutesBeamStack.constructor() -- $debugLabel -- $creationReason');
-  }
+  }) : super(routeInformation, beamParameters);
 
   final BeamerDelegate parent;
 
@@ -525,9 +514,6 @@ class RoutesBeamStack extends BeamStack<BeamState> {
     final pages = sortedRoutes.indexed.map<BeamPage>((value) {
       final index = value.$1;
       final route = value.$2;
-      // final notifierReference = BeamPageNotifierReference();
-      // final routeElement =
-      //     routes[route]!(context, state, notifierReference, data);
       final routeElement = routes[route]!(context, state, data);
       final page = routeElement is BeamPage
           ? routeElement
@@ -535,18 +521,15 @@ class RoutesBeamStack extends BeamStack<BeamState> {
               key: ValueKey(filteredRoutes[route]),
               child: routeElement,
             );
-      print('Notifier exists: ${parent.pageNotifiers.containsKey(page.key)}');
+
+      // Initializing page state
       final stateChangeNotifier = page.stateChangeNotifier;
       if (stateChangeNotifier != null) {
         parent.pageNotifiers[page.key] = stateChangeNotifier;
         stateChangeNotifier.value =
             BeamPageState(isPinnacle: index == sortedRoutes.length - 1);
       }
-      // final notifier = parent.pageNotifiers[page.key] ??= BeamPageNotifier(
-      //   BeamPageState(isPinnacle: index == sortedRoutes.length - 1),
-      //   parentStackDebugLabel: debugLabel,
-      // );
-      // notifierReference.getNotifier = () => notifier;
+
       return page;
     }).toList();
 

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -88,14 +88,17 @@ abstract class BeamStack<T extends RouteInformationSerializable>
   /// Creates a [BeamStack] with specified properties.
   ///
   /// All attributes can be null.
-  BeamStack([
+  BeamStack(
+    this.debugLabel, [
     RouteInformation? routeInformation,
     BeamParameters? beamParameters,
   ]) {
     create(routeInformation, beamParameters);
   }
 
-  final debugLabel = DateTime.now().millisecondsSinceEpoch.toString();
+  // final debugLabel = DateTime.now().millisecondsSinceEpoch.toString();
+
+  final String debugLabel;
 
   late T _state;
 
@@ -263,7 +266,7 @@ abstract class BeamStack<T extends RouteInformationSerializable>
   }
 
   /// The history of beaming for this.
-  List<HistoryElement> history = [];
+  final List<HistoryElement> history = [];
 
   /// Adds another [HistoryElement] to [history] list.
   /// The history element is created from given [state] and [beamParameters].
@@ -396,7 +399,8 @@ abstract class BeamStack<T extends RouteInformationSerializable>
 class NotFound extends BeamStack<BeamState> {
   /// Creates a [NotFound] [BeamStack] with
   /// `RouteInformation(uri: Uri.parse(path)` as its state.
-  NotFound({String path = '/'}) : super(RouteInformation(uri: Uri.parse(path)));
+  NotFound({String path = '/'})
+      : super('NotFound', RouteInformation(uri: Uri.parse(path)));
 
   @override
   List<BeamPage> buildPages(BuildContext context, BeamState state) => [];
@@ -409,6 +413,8 @@ class NotFound extends BeamStack<BeamState> {
 ///
 /// See [BeamerDelegate.currentBeamStack].
 class EmptyBeamStack extends BeamStack<BeamState> {
+  EmptyBeamStack() : super('EmptyBeamStack');
+
   @override
   List<BeamPage> buildPages(BuildContext context, BeamState state) => [];
 
@@ -423,7 +429,7 @@ class GuardShowPage extends BeamStack<BeamState> {
   GuardShowPage(
     this.routeInformation,
     this.beamPage,
-  ) : super(routeInformation);
+  ) : super('GuardShowPage', routeInformation);
 
   /// [RouteInformation] to show in URL
   final RouteInformation routeInformation;
@@ -447,15 +453,18 @@ class RoutesBeamStack extends BeamStack<BeamState> {
   ///
   /// [routeInformation] and [routes] are required.
   RoutesBeamStack({
+    required String debugLabel,
     required RouteInformation routeInformation,
     Object? data,
     BeamParameters? beamParameters,
     required this.routes,
     this.navBuilder,
-  }) : super(routeInformation, beamParameters);
+  }) : super(debugLabel, routeInformation, beamParameters) {
+    print('RoutesBeamStack.constructor() -- $debugLabel');
+  }
 
   /// Map of all routes this stack handles.
-  Map<
+  final Map<
       Pattern,
       dynamic Function(
         BuildContext,
@@ -466,7 +475,7 @@ class RoutesBeamStack extends BeamStack<BeamState> {
       )> routes;
 
   /// A wrapper used as [BeamStack.builder].
-  Widget Function(BuildContext context, Widget navigator)? navBuilder;
+  final Widget Function(BuildContext context, Widget navigator)? navBuilder;
 
   /// They are regenerated on [buildPages],
   /// so they are only valid for one build cycle.
@@ -503,7 +512,7 @@ class RoutesBeamStack extends BeamStack<BeamState> {
 
   @override
   List<BeamPage> buildPages(BuildContext context, BeamState state) {
-    _printCurrentPageNotifiers('buildPages');
+    // _printCurrentPageNotifiers('buildPages');
 
     final filteredRoutes = chooseRoutes(state.routeInformation, routes.keys);
     final routeBuilders = Map.of(routes)
@@ -630,7 +639,7 @@ class RoutesBeamStack extends BeamStack<BeamState> {
   }
 
   void notifyPages(List<BeamPage> pages) {
-    _printCurrentPageNotifiers('notifyPages');
+    // _printCurrentPageNotifiers('notifyPages');
 
     // Hidden pages
     for (int i = 0; i < pages.length - 1; i++) {
@@ -655,10 +664,10 @@ class RoutesBeamStack extends BeamStack<BeamState> {
     // return notifiers;
   }
 
-  void _printCurrentPageNotifiers(String debugLabel) {
-    print('_printCurrentPageNotifiers() -- ${this.debugLabel} -- $debugLabel');
-    for (final entry in _pageNotifiers.entries) {
-      print('LocalKey: ${entry.key}, Notifier: ${entry.value.fullDebugLabel}');
-    }
-  }
+  // void _printCurrentPageNotifiers(String debugLabel) {
+  //   print('_printCurrentPageNotifiers() -- ${this.debugLabel} -- $debugLabel');
+  //   for (final entry in _pageNotifiers.entries) {
+  //     print('LocalKey: ${entry.key}, Notifier: ${entry.value.fullDebugLabel}');
+  //   }
+  // }
 }

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -474,7 +474,8 @@ class RoutesBeamStack extends BeamStack<BeamState> {
         BuildContext,
         BeamState,
         // BeamPageNotifier,
-        BeamPageNotifierReference,
+        // BeamPageNotifierReference,
+        // BeamPageStateNotifier,
         Object? data,
       )> routes;
 
@@ -524,9 +525,10 @@ class RoutesBeamStack extends BeamStack<BeamState> {
     final pages = sortedRoutes.indexed.map<BeamPage>((value) {
       final index = value.$1;
       final route = value.$2;
-      final notifierReference = BeamPageNotifierReference();
-      final routeElement =
-          routes[route]!(context, state, notifierReference, data);
+      // final notifierReference = BeamPageNotifierReference();
+      // final routeElement =
+      //     routes[route]!(context, state, notifierReference, data);
+      final routeElement = routes[route]!(context, state, data);
       final page = routeElement is BeamPage
           ? routeElement
           : BeamPage(
@@ -534,11 +536,17 @@ class RoutesBeamStack extends BeamStack<BeamState> {
               child: routeElement,
             );
       print('Notifier exists: ${parent.pageNotifiers.containsKey(page.key)}');
-      final notifier = parent.pageNotifiers[page.key] ??= BeamPageNotifier(
-        BeamPageState(isPinnacle: index == sortedRoutes.length - 1),
-        parentStackDebugLabel: debugLabel,
-      );
-      notifierReference.getNotifier = () => notifier;
+      final stateChangeNotifier = page.stateChangeNotifier;
+      if (stateChangeNotifier != null) {
+        parent.pageNotifiers[page.key] = stateChangeNotifier;
+        stateChangeNotifier.value =
+            BeamPageState(isPinnacle: index == sortedRoutes.length - 1);
+      }
+      // final notifier = parent.pageNotifiers[page.key] ??= BeamPageNotifier(
+      //   BeamPageState(isPinnacle: index == sortedRoutes.length - 1),
+      //   parentStackDebugLabel: debugLabel,
+      // );
+      // notifierReference.getNotifier = () => notifier;
       return page;
     }).toList();
 

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -453,7 +453,14 @@ class RoutesBeamStack extends BeamStack<BeamState> {
   }) : super(routeInformation, beamParameters);
 
   /// Map of all routes this stack handles.
-  Map<Pattern, dynamic Function(BuildContext, BeamState, Object? data)> routes;
+  Map<
+      Pattern,
+      dynamic Function(
+        BuildContext,
+        BeamState,
+        Object? data,
+        bool isPinnacle,
+      )> routes;
 
   /// A wrapper used as [BeamStack.builder].
   Widget Function(BuildContext context, Widget navigator)? navBuilder;
@@ -489,8 +496,12 @@ class RoutesBeamStack extends BeamStack<BeamState> {
       ..removeWhere((key, value) => !filteredRoutes.containsKey(key));
     final sortedRoutes = routeBuilders.keys.toList()
       ..sort((a, b) => _compareKeys(a, b));
-    final pages = sortedRoutes.map<BeamPage>((route) {
-      final routeElement = routes[route]!(context, state, data);
+    final sortedRoutesLength = sortedRoutes.length;
+    final pages = sortedRoutes.indexed.map<BeamPage>((indexedRoute) {
+      final index = indexedRoute.$1;
+      final route = indexedRoute.$2;
+      final routeElement =
+          routes[route]!(context, state, data, index == sortedRoutesLength - 1);
       if (routeElement is BeamPage) {
         return routeElement;
       } else {

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -461,9 +461,6 @@ class RoutesBeamStack extends BeamStack<BeamState> {
       dynamic Function(
         BuildContext,
         BeamState,
-        // BeamPageNotifier,
-        // BeamPageNotifierReference,
-        // BeamPageStateNotifier,
         Object? data,
       )> routes;
 

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -454,13 +454,14 @@ class RoutesBeamStack extends BeamStack<BeamState> {
   /// [routeInformation] and [routes] are required.
   RoutesBeamStack({
     required String debugLabel,
+    required String creationReason,
     required RouteInformation routeInformation,
     Object? data,
     BeamParameters? beamParameters,
     required this.routes,
     this.navBuilder,
   }) : super(debugLabel, routeInformation, beamParameters) {
-    print('RoutesBeamStack.constructor() -- $debugLabel');
+    print('RoutesBeamStack.constructor() -- $debugLabel -- $creationReason');
   }
 
   /// Map of all routes this stack handles.

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -462,15 +462,6 @@ class RoutesBeamStack extends BeamStack<BeamState> {
   /// A wrapper used as [BeamStack.builder].
   final Widget Function(BuildContext context, Widget navigator)? navBuilder;
 
-  /// They are regenerated on [buildPages],
-  /// so they are only valid for one build cycle.
-  ///
-  /// The reason for not making them persistent across build cycles is that
-  /// we can't know the [BeamPage.key] before creating them (see [buildPages]).
-  // final Map<LocalKey, BeamPageNotifier> _pageNotifiers = {};
-  // final List<BeamPageNotifier> _pageNotifiers = [];
-  // final Map<ValueKey, BeamPageNotifier> _pageNotifiers = {};
-
   @override
   Widget builder(BuildContext context, Widget navigator) {
     return navBuilder?.call(context, navigator) ?? navigator;

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -456,13 +456,8 @@ class RoutesBeamStack extends BeamStack<BeamState> {
   final BeamerDelegate parent;
 
   /// Map of all routes this stack handles.
-  final Map<
-      Pattern,
-      dynamic Function(
-        BuildContext,
-        BeamState,
-        Object? data,
-      )> routes;
+  final Map<Pattern, dynamic Function(BuildContext, BeamState, Object? data)>
+      routes;
 
   /// A wrapper used as [BeamStack.builder].
   final Widget Function(BuildContext context, Widget navigator)? navBuilder;

--- a/package/lib/src/beam_stack.dart
+++ b/package/lib/src/beam_stack.dart
@@ -507,9 +507,8 @@ class RoutesBeamStack extends BeamStack<BeamState> {
       // Initializing page state
       final stateChangeNotifier = page.stateChangeNotifier;
       if (stateChangeNotifier != null) {
-        parent.pageNotifiers[page.key] = stateChangeNotifier;
-        stateChangeNotifier.value =
-            BeamPageState(isPinnacle: index == sortedRoutes.length - 1);
+        parent.pageNotifiers[page.key] = stateChangeNotifier
+          ..value = BeamPageState(isPinnacle: index == sortedRoutes.length - 1);
       }
 
       return page;

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -50,6 +50,11 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     updateListenable?.addListener(_update);
   }
 
+  /// They are regenerated on [buildPages],
+  /// so they are only valid for one build cycle.
+  ///
+  /// The reason for not making them persistent across build cycles is that
+  /// we can't know the [BeamPage.key] before creating them (see [buildPages]).
   final Map<LocalKey, BeamPageStateNotifier> pageNotifiers = {};
 
   bool _firstBuild = true;

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -10,7 +10,8 @@ import 'package:flutter/services.dart';
 /// A delegate that is used by the [Router] to build the [Navigator].
 ///
 /// This is "the beamer", the one that does the actual beaming.
-class BeamerDelegate extends RouterDelegate<RouteInformation>
+class BeamerDelegate<T extends BeamPageInfo>
+    extends RouterDelegate<RouteInformation>
     with ChangeNotifier, PopNavigatorRouterDelegateMixin<RouteInformation> {
   /// Creates a [BeamerDelegate] with specified properties.
   ///
@@ -355,6 +356,12 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
   /// This is important for first build, i.e. [setInitialRoutePath],
   /// to avoid setting URL when the guards have not been run yet.
   bool _initialConfigurationReady = false;
+
+  final pinnaclePageInfoNotifier = BeamPageInfoNotifier<T>();
+
+  T? _pinnaclePageInfo;
+
+  T? get pinnaclePageInfo => _pinnaclePageInfo;
 
   /// Main method to update the [configuration] of this delegate and its
   /// [currentBeamStack].
@@ -997,12 +1004,18 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     if (currentBeamStack is NotFound) {
       _currentPages = [notFoundPage];
       pageNotifiers.clear();
+      _pinnaclePageInfo = null;
     } else {
       _currentPages = _currentBeamParameters.stacked
           ? currentBeamStack.buildPages(context, currentBeamStack.state)
           : [currentBeamStack.buildPages(context, currentBeamStack.state).last];
       _purgePageStateNotifiers();
+      _pinnaclePageInfo = _currentPages.lastOrNull?.info as T?;
     }
+
+    pinnaclePageInfoNotifier
+      ..value = _pinnaclePageInfo
+      ..notifyListeners();
   }
 
   /// Purges outdated page state notifiers.

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -770,11 +770,6 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     final isFirstBuild = this._firstBuild;
     _firstBuild = false;
 
-    // final current = currentBeamStack;
-
-    // print(
-    //     'BeamerDelegate.build() -- I -- $debugLabel -- ${current.debugLabel} -- Is first build: $isFirstBuild -- Type: ${current.runtimeType}');
-
     _buildInProgress = true;
     _context = context;
 
@@ -797,25 +792,17 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
 
     final navigator = Builder(
       builder: (context) {
-        // final current = currentBeamStack;
-
-        // print(
-        //     'BeamerDelegate.build() -- II -- $debugLabel -- ${current.debugLabel} -- Is first build: $isFirstBuild -- Type: ${current.runtimeType}');
-
         _setCurrentPages(context);
-
-        // print(
-        //     'BeamerDelegate.build() -- $_debugLabel -- Builder page length: ${_currentPages.length}');
 
         _setBrowserTitle(context);
 
         buildListener?.call(context, this);
 
+        _printCurrentPageNotifiers();
+
         // Notifying pages
         if (!isFirstBuild) {
-          final count = _notifyCurrentPages();
-          // print(
-          //     'BeamerDelegate.build() -- $debugLabel -- Notified pages: $count');
+          _notifyCurrentPages();
         }
 
         return Navigator(
@@ -1032,15 +1019,33 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     }
   }
 
-  int _notifyCurrentPages() {
+  void _notifyCurrentPages() {
     final stack = currentBeamStack;
 
     if (stack is! RoutesBeamStack) {
-      return 0;
+      return;
     }
 
-    stack.notifyPages(_currentPages);
-    return _currentPages.length;
+    // Hidden pages
+    for (int i = 0; i < _currentPages.length - 1; i++) {
+      print('Notifying page: ${_currentPages[i].title} -- Is pinnacle: false');
+      pageNotifiers[_currentPages[i].key]!
+        ..value = BeamPageState(isPinnacle: false)
+        ..notify();
+    }
+
+    // Pinnacle page
+    print('Notifying page: ${_currentPages.last.title} -- Is pinnacle: true');
+    pageNotifiers[_currentPages.last.key]!
+      ..value = BeamPageState(isPinnacle: true)
+      ..notify();
+  }
+
+  void _printCurrentPageNotifiers() {
+    print('_printCurrentPageNotifiers()');
+    for (final entry in pageNotifiers.entries) {
+      print('LocalKey: ${entry.key}, Notifier: ${entry.value.fullDebugLabel}');
+    }
   }
 
   void _setBrowserTitle(BuildContext context) {

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -50,11 +50,6 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     updateListenable?.addListener(_update);
   }
 
-  /// They are regenerated on [buildPages],
-  /// so they are only valid for one build cycle.
-  ///
-  /// The reason for not making them persistent across build cycles is that
-  /// we can't know the [BeamPage.key] before creating them (see [buildPages]).
   final Map<LocalKey, BeamPageStateNotifier> pageNotifiers = {};
 
   bool _firstBuild = true;

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -42,7 +42,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     this.updateParent = true,
     this.clearBeamingHistoryOn = const <String>{},
   }) {
-    print('BeamerDelegate.constructor() -- $debugLabel');
+    // print('BeamerDelegate.constructor() -- $debugLabel');
 
     _currentBeamParameters = BeamParameters(
       transitionDelegate: transitionDelegate,
@@ -52,6 +52,8 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
 
     updateListenable?.addListener(_update);
   }
+
+  final Map<LocalKey, BeamPageNotifier> pageNotifiers = {};
 
   bool _firstBuild = true;
 
@@ -433,6 +435,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     if (buildBeamStack) {
       // build a BeamStack from configuration
       _beamStackCandidate = stackBuilder(
+        this,
         this.configuration.copyWith(),
         _currentBeamParameters,
         'update',
@@ -767,10 +770,10 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     final isFirstBuild = this._firstBuild;
     _firstBuild = false;
 
-    final current = currentBeamStack;
+    // final current = currentBeamStack;
 
-    print(
-        'BeamerDelegate.build() -- I -- $debugLabel -- ${current.debugLabel} -- Is first build: $isFirstBuild -- Type: ${current.runtimeType}');
+    // print(
+    //     'BeamerDelegate.build() -- I -- $debugLabel -- ${current.debugLabel} -- Is first build: $isFirstBuild -- Type: ${current.runtimeType}');
 
     _buildInProgress = true;
     _context = context;
@@ -794,10 +797,10 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
 
     final navigator = Builder(
       builder: (context) {
-        final current = currentBeamStack;
+        // final current = currentBeamStack;
 
-        print(
-            'BeamerDelegate.build() -- II -- $debugLabel -- ${current.debugLabel} -- Is first build: $isFirstBuild -- Type: ${current.runtimeType}');
+        // print(
+        //     'BeamerDelegate.build() -- II -- $debugLabel -- ${current.debugLabel} -- Is first build: $isFirstBuild -- Type: ${current.runtimeType}');
 
         _setCurrentPages(context);
 
@@ -811,8 +814,8 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
         // Notifying pages
         if (!isFirstBuild) {
           final count = _notifyCurrentPages();
-          print(
-              'BeamerDelegate.build() -- $debugLabel -- Notified pages: $count');
+          // print(
+          //     'BeamerDelegate.build() -- $debugLabel -- Notified pages: $count');
         }
 
         return Navigator(
@@ -1004,6 +1007,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
       _beamStackCandidate = notFoundRedirect!;
     } else if (notFoundRedirectNamed != null) {
       _beamStackCandidate = stackBuilder(
+        this,
         RouteInformation(uri: Uri.parse(notFoundRedirectNamed!)),
         _currentBeamParameters.copyWith(),
         '_handleNotFoundRedirect',
@@ -1100,6 +1104,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     final parentConfiguration = _parent!.configuration.copyWith();
     if (initializeFromParent) {
       _beamStackCandidate = stackBuilder(
+        this,
         parentConfiguration,
         _currentBeamParameters,
         '_initializeChild',
@@ -1134,6 +1139,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
   void _updateFromParent({bool rebuild = true}) {
     final parentConfiguration = _parent!.configuration.copyWith();
     final beamStack = stackBuilder(
+      this,
       parentConfiguration,
       _currentBeamParameters,
       '_updateFromParent',

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -435,6 +435,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
       _beamStackCandidate = stackBuilder(
         this.configuration.copyWith(),
         _currentBeamParameters,
+        'update',
       );
     }
 
@@ -1005,6 +1006,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
       _beamStackCandidate = stackBuilder(
         RouteInformation(uri: Uri.parse(notFoundRedirectNamed!)),
         _currentBeamParameters.copyWith(),
+        '_handleNotFoundRedirect',
       );
     }
     _updateFromBeamStackCandidate();
@@ -1097,8 +1099,11 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
   void _initializeChild() {
     final parentConfiguration = _parent!.configuration.copyWith();
     if (initializeFromParent) {
-      _beamStackCandidate =
-          stackBuilder(parentConfiguration, _currentBeamParameters);
+      _beamStackCandidate = stackBuilder(
+        parentConfiguration,
+        _currentBeamParameters,
+        '_initializeChild',
+      );
     }
 
     // If this couldn't handle parents configuration,
@@ -1128,7 +1133,11 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
   // Updates only if it can handle the configuration
   void _updateFromParent({bool rebuild = true}) {
     final parentConfiguration = _parent!.configuration.copyWith();
-    final beamStack = stackBuilder(parentConfiguration, _currentBeamParameters);
+    final beamStack = stackBuilder(
+      parentConfiguration,
+      _currentBeamParameters,
+      '_updateFromParent',
+    );
 
     if (beamStack is! NotFound) {
       update(

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -17,7 +17,6 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
   /// [stackBuilder] is required to process the incoming navigation request.
   BeamerDelegate({
     required this.stackBuilder,
-    required this.debugLabel,
     this.initialPath = '/',
     this.routeListener,
     this.buildListener,
@@ -42,8 +41,6 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     this.updateParent = true,
     this.clearBeamingHistoryOn = const <String>{},
   }) {
-    // print('BeamerDelegate.constructor() -- $debugLabel');
-
     _currentBeamParameters = BeamParameters(
       transitionDelegate: transitionDelegate,
     );
@@ -66,10 +63,6 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
   BeamerDelegate? _parent;
 
   final Set<BeamerDelegate> _children = {};
-
-  final String debugLabel;
-
-  // final _debugLabel = DateTime.now().millisecondsSinceEpoch.toString();
 
   /// Takes priority over all other siblings,
   /// i.e. sets itself as active and all other siblings as inactive.
@@ -798,8 +791,6 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
 
         buildListener?.call(context, this);
 
-        _printCurrentPageNotifiers();
-
         // Notifying pages
         if (!isFirstBuild) {
           _notifyCurrentPages();
@@ -1006,10 +997,6 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
   void _setCurrentPages(BuildContext context) {
     final currentBeamStack = this.currentBeamStack;
 
-    if (currentBeamStack is RoutesBeamStack) {
-      print('_setCurrentPages() -- ${currentBeamStack.debugLabel}');
-    }
-
     if (currentBeamStack is NotFound) {
       _currentPages = [notFoundPage];
       pageNotifiers.clear();
@@ -1017,17 +1004,15 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
       _currentPages = _currentBeamParameters.stacked
           ? currentBeamStack.buildPages(context, currentBeamStack.state)
           : [currentBeamStack.buildPages(context, currentBeamStack.state).last];
-      _purgePageNotifiers();
+      _purgePageStateNotifiers();
     }
   }
 
-  /// Purging outdated page notifiers.
-  void _purgePageNotifiers() {
+  /// Purges outdated page state notifiers.
+  void _purgePageStateNotifiers() {
     final currentPagesKeys = _currentPages.map((page) => page.key);
-    print('_purgePageNotifiers() -- 1 -- ${pageNotifiers.length}');
     pageNotifiers
         .removeWhere((key, pageNotifier) => !currentPagesKeys.contains(key));
-    print('_purgePageNotifiers() -- 2 -- ${pageNotifiers.length}');
   }
 
   void _notifyCurrentPages() {
@@ -1039,24 +1024,15 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
 
     // Hidden pages
     for (int i = 0; i < _currentPages.length - 1; i++) {
-      print('Notifying page: ${_currentPages[i].title} -- Is pinnacle: false');
       pageNotifiers[_currentPages[i].key]!
         ..value = BeamPageState(isPinnacle: false)
         ..notifyListeners();
     }
 
     // Pinnacle page
-    print('Notifying page: ${_currentPages.last.title} -- Is pinnacle: true');
     pageNotifiers[_currentPages.last.key]!
       ..value = BeamPageState(isPinnacle: true)
       ..notifyListeners();
-  }
-
-  void _printCurrentPageNotifiers() {
-    print('_printCurrentPageNotifiers()');
-    for (final entry in pageNotifiers.entries) {
-      print('LocalKey: ${entry.key}');
-    }
   }
 
   void _setBrowserTitle(BuildContext context) {

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -1012,11 +1012,22 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
 
     if (currentBeamStack is NotFound) {
       _currentPages = [notFoundPage];
+      pageNotifiers.clear();
     } else {
       _currentPages = _currentBeamParameters.stacked
           ? currentBeamStack.buildPages(context, currentBeamStack.state)
           : [currentBeamStack.buildPages(context, currentBeamStack.state).last];
+      _purgePageNotifiers();
     }
+  }
+
+  /// Purging outdated page notifiers.
+  void _purgePageNotifiers() {
+    final currentPagesKeys = _currentPages.map((page) => page.key);
+    print('_purgePageNotifiers() -- 1 -- ${pageNotifiers.length}');
+    pageNotifiers
+        .removeWhere((key, pageNotifier) => !currentPagesKeys.contains(key));
+    print('_purgePageNotifiers() -- 2 -- ${pageNotifiers.length}');
   }
 
   void _notifyCurrentPages() {

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -359,10 +359,6 @@ class BeamerDelegate<T extends BeamPageInfo>
 
   final pinnaclePageInfoNotifier = BeamPageInfoNotifier<T>();
 
-  // T? _pinnaclePageInfo;
-
-  // T? get pinnaclePageInfo => _pinnaclePageInfo;
-
   /// Main method to update the [configuration] of this delegate and its
   /// [currentBeamStack].
   ///

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -53,7 +53,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     updateListenable?.addListener(_update);
   }
 
-  final Map<LocalKey, BeamPageNotifier> pageNotifiers = {};
+  final Map<LocalKey, BeamPageStateNotifier> pageNotifiers = {};
 
   bool _firstBuild = true;
 
@@ -1042,20 +1042,20 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
       print('Notifying page: ${_currentPages[i].title} -- Is pinnacle: false');
       pageNotifiers[_currentPages[i].key]!
         ..value = BeamPageState(isPinnacle: false)
-        ..notify();
+        ..notifyListeners();
     }
 
     // Pinnacle page
     print('Notifying page: ${_currentPages.last.title} -- Is pinnacle: true');
     pageNotifiers[_currentPages.last.key]!
       ..value = BeamPageState(isPinnacle: true)
-      ..notify();
+      ..notifyListeners();
   }
 
   void _printCurrentPageNotifiers() {
     print('_printCurrentPageNotifiers()');
     for (final entry in pageNotifiers.entries) {
-      print('LocalKey: ${entry.key}, Notifier: ${entry.value.fullDebugLabel}');
+      print('LocalKey: ${entry.key}');
     }
   }
 

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -761,8 +761,10 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     final isFirstBuild = this._firstBuild;
     _firstBuild = false;
 
+    final current = currentBeamStack;
+
     print(
-        'BeamerDelegate.build() -- $_debugLabel -- Is first build: $isFirstBuild');
+        'BeamerDelegate.build() -- I -- $_debugLabel -- ${current.debugLabel} -- Is first build: $isFirstBuild -- Type: ${current.runtimeType}');
 
     _buildInProgress = true;
     _context = context;
@@ -786,6 +788,11 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
 
     final navigator = Builder(
       builder: (context) {
+        final current = currentBeamStack;
+
+        print(
+            'BeamerDelegate.build() -- II -- $_debugLabel -- ${current.debugLabel} -- Is first build: $isFirstBuild -- Type: ${current.runtimeType}');
+
         _setCurrentPages(context);
 
         // print(
@@ -999,6 +1006,12 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
   }
 
   void _setCurrentPages(BuildContext context) {
+    final currentBeamStack = this.currentBeamStack;
+
+    if (currentBeamStack is RoutesBeamStack) {
+      print('_setCurrentPages() -- ${currentBeamStack.debugLabel}');
+    }
+
     if (currentBeamStack is NotFound) {
       _currentPages = [notFoundPage];
     } else {

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -431,7 +431,6 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
         this,
         this.configuration.copyWith(),
         _currentBeamParameters,
-        'update',
       );
     }
 
@@ -988,7 +987,6 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
         this,
         RouteInformation(uri: Uri.parse(notFoundRedirectNamed!)),
         _currentBeamParameters.copyWith(),
-        '_handleNotFoundRedirect',
       );
     }
     _updateFromBeamStackCandidate();
@@ -1099,7 +1097,6 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
         this,
         parentConfiguration,
         _currentBeamParameters,
-        '_initializeChild',
       );
     }
 
@@ -1134,7 +1131,6 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
       this,
       parentConfiguration,
       _currentBeamParameters,
-      '_updateFromParent',
     );
 
     if (beamStack is! NotFound) {

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -17,6 +17,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
   /// [stackBuilder] is required to process the incoming navigation request.
   BeamerDelegate({
     required this.stackBuilder,
+    required this.debugLabel,
     this.initialPath = '/',
     this.routeListener,
     this.buildListener,
@@ -41,6 +42,8 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     this.updateParent = true,
     this.clearBeamingHistoryOn = const <String>{},
   }) {
+    print('BeamerDelegate.constructor() -- $debugLabel');
+
     _currentBeamParameters = BeamParameters(
       transitionDelegate: transitionDelegate,
     );
@@ -62,7 +65,9 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
 
   final Set<BeamerDelegate> _children = {};
 
-  final _debugLabel = DateTime.now().millisecondsSinceEpoch.toString();
+  final String debugLabel;
+
+  // final _debugLabel = DateTime.now().millisecondsSinceEpoch.toString();
 
   /// Takes priority over all other siblings,
   /// i.e. sets itself as active and all other siblings as inactive.
@@ -764,7 +769,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     final current = currentBeamStack;
 
     print(
-        'BeamerDelegate.build() -- I -- $_debugLabel -- ${current.debugLabel} -- Is first build: $isFirstBuild -- Type: ${current.runtimeType}');
+        'BeamerDelegate.build() -- I -- $debugLabel -- ${current.debugLabel} -- Is first build: $isFirstBuild -- Type: ${current.runtimeType}');
 
     _buildInProgress = true;
     _context = context;
@@ -791,7 +796,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
         final current = currentBeamStack;
 
         print(
-            'BeamerDelegate.build() -- II -- $_debugLabel -- ${current.debugLabel} -- Is first build: $isFirstBuild -- Type: ${current.runtimeType}');
+            'BeamerDelegate.build() -- II -- $debugLabel -- ${current.debugLabel} -- Is first build: $isFirstBuild -- Type: ${current.runtimeType}');
 
         _setCurrentPages(context);
 
@@ -806,7 +811,7 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
         if (!isFirstBuild) {
           final count = _notifyCurrentPages();
           print(
-              'BeamerDelegate.build() -- $_debugLabel -- Notified pages: $count');
+              'BeamerDelegate.build() -- $debugLabel -- Notified pages: $count');
         }
 
         return Navigator(

--- a/package/lib/src/beamer_delegate.dart
+++ b/package/lib/src/beamer_delegate.dart
@@ -785,7 +785,6 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
     final navigator = Builder(
       builder: (context) {
         _setCurrentPages(context);
-
         _setBrowserTitle(context);
 
         buildListener?.call(context, this);
@@ -1093,11 +1092,8 @@ class BeamerDelegate extends RouterDelegate<RouteInformation>
   void _initializeChild() {
     final parentConfiguration = _parent!.configuration.copyWith();
     if (initializeFromParent) {
-      _beamStackCandidate = stackBuilder(
-        this,
-        parentConfiguration,
-        _currentBeamParameters,
-      );
+      _beamStackCandidate =
+          stackBuilder(this, parentConfiguration, _currentBeamParameters);
     }
 
     // If this couldn't handle parents configuration,

--- a/package/lib/src/stack_builders.dart
+++ b/package/lib/src/stack_builders.dart
@@ -47,30 +47,20 @@ class RoutesStackBuilder {
   /// Creates a [RoutesStackBuilder] with specified properties.
   ///
   /// [routes] are required to build pages from.
-  RoutesStackBuilder({
-    required this.routes,
-    this.builder,
-  });
+  RoutesStackBuilder({required this.routes, this.builder});
 
   /// List of all routes this builder handles.
   ///
   /// isPinnacle is true when the route is the outer/last in the stack.
-  final Map<
-      Pattern,
-      dynamic Function(
-        BuildContext,
-        BeamState,
-        // BeamPageNotifierReference,
-        // BeamPageStateNotifier,
-        Object?,
-      )> routes;
+  final Map<Pattern, dynamic Function(BuildContext, BeamState, Object?)> routes;
 
   /// Used as a [BeamStack.builder].
   final Widget Function(BuildContext context, Widget navigator)? builder;
 
   /// Makes this callable as [StackBuilder].
   ///
-  /// Returns [RoutesBeamStack] configured with chosen routes from [routes] or [NotFound].
+  /// Returns [RoutesBeamStack] configured with chosen routes from [routes]
+  /// or [NotFound].
   BeamStack call(
     BeamerDelegate parent,
     RouteInformation routeInformation,

--- a/package/lib/src/stack_builders.dart
+++ b/package/lib/src/stack_builders.dart
@@ -64,7 +64,6 @@ class RoutesStackBuilder {
       dynamic Function(
         BuildContext,
         BeamState,
-        // BeamPageNotifier,
         BeamPageNotifierReference,
         Object?,
       )> routes;

--- a/package/lib/src/stack_builders.dart
+++ b/package/lib/src/stack_builders.dart
@@ -5,6 +5,7 @@ import 'package:beamer/src/utils.dart';
 
 /// A convenience typedef for [BeamerDelegate.stackBuilder].
 typedef StackBuilder = BeamStack Function(
+  BeamerDelegate parent,
   RouteInformation,
   BeamParameters?,
   String creationReason,
@@ -75,6 +76,7 @@ class RoutesStackBuilder {
   ///
   /// Returns [RoutesBeamStack] configured with chosen routes from [routes] or [NotFound].
   BeamStack call(
+    BeamerDelegate parent,
     RouteInformation routeInformation,
     BeamParameters? beamParameters,
     String creationReason,
@@ -82,6 +84,7 @@ class RoutesStackBuilder {
     final matched = RoutesBeamStack.chooseRoutes(routeInformation, routes.keys);
     if (matched.isNotEmpty) {
       return RoutesBeamStack(
+        parent: parent,
         debugLabel: '$debugLabel -- ${DateTime.now().millisecondsSinceEpoch}',
         creationReason: creationReason,
         routeInformation: routeInformation,

--- a/package/lib/src/stack_builders.dart
+++ b/package/lib/src/stack_builders.dart
@@ -49,7 +49,16 @@ class RoutesStackBuilder {
   RoutesStackBuilder({required this.routes, this.builder});
 
   /// List of all routes this builder handles.
-  final Map<Pattern, dynamic Function(BuildContext, BeamState, Object?)> routes;
+  ///
+  /// isPinnacle is true when the route is the outer/last in the stack.
+  final Map<
+      Pattern,
+      dynamic Function(
+        BuildContext,
+        BeamState,
+        Object?,
+        bool isPinnacle,
+      )> routes;
 
   /// Used as a [BeamStack.builder].
   Widget Function(BuildContext context, Widget navigator)? builder;

--- a/package/lib/src/stack_builders.dart
+++ b/package/lib/src/stack_builders.dart
@@ -49,12 +49,9 @@ class RoutesStackBuilder {
   ///
   /// [routes] are required to build pages from.
   RoutesStackBuilder({
-    required this.debugLabel,
     required this.routes,
     this.builder,
   });
-
-  final String debugLabel;
 
   /// List of all routes this builder handles.
   ///
@@ -85,7 +82,6 @@ class RoutesStackBuilder {
     if (matched.isNotEmpty) {
       return RoutesBeamStack(
         parent: parent,
-        debugLabel: '$debugLabel -- ${DateTime.now().millisecondsSinceEpoch}',
         creationReason: creationReason,
         routeInformation: routeInformation,
         routes: routes,

--- a/package/lib/src/stack_builders.dart
+++ b/package/lib/src/stack_builders.dart
@@ -8,7 +8,6 @@ typedef StackBuilder = BeamStack Function(
   BeamerDelegate parent,
   RouteInformation,
   BeamParameters?,
-  String creationReason,
 );
 
 /// A pre-made builder to be used for [BeamerDelegate.stackBuilder].

--- a/package/lib/src/stack_builders.dart
+++ b/package/lib/src/stack_builders.dart
@@ -50,8 +50,6 @@ class RoutesStackBuilder {
   RoutesStackBuilder({required this.routes, this.builder});
 
   /// List of all routes this builder handles.
-  ///
-  /// isPinnacle is true when the route is the outer/last in the stack.
   final Map<Pattern, dynamic Function(BuildContext, BeamState, Object?)> routes;
 
   /// Used as a [BeamStack.builder].

--- a/package/lib/src/stack_builders.dart
+++ b/package/lib/src/stack_builders.dart
@@ -64,7 +64,8 @@ class RoutesStackBuilder {
       dynamic Function(
         BuildContext,
         BeamState,
-        BeamPageNotifierReference,
+        // BeamPageNotifierReference,
+        // BeamPageStateNotifier,
         Object?,
       )> routes;
 

--- a/package/lib/src/stack_builders.dart
+++ b/package/lib/src/stack_builders.dart
@@ -46,7 +46,13 @@ class RoutesStackBuilder {
   /// Creates a [RoutesStackBuilder] with specified properties.
   ///
   /// [routes] are required to build pages from.
-  RoutesStackBuilder({required this.routes, this.builder});
+  RoutesStackBuilder({
+    required this.debugLabel,
+    required this.routes,
+    this.builder,
+  });
+
+  final String debugLabel;
 
   /// List of all routes this builder handles.
   ///
@@ -62,7 +68,7 @@ class RoutesStackBuilder {
       )> routes;
 
   /// Used as a [BeamStack.builder].
-  Widget Function(BuildContext context, Widget navigator)? builder;
+  final Widget Function(BuildContext context, Widget navigator)? builder;
 
   /// Makes this callable as [StackBuilder].
   ///
@@ -74,6 +80,7 @@ class RoutesStackBuilder {
     final matched = RoutesBeamStack.chooseRoutes(routeInformation, routes.keys);
     if (matched.isNotEmpty) {
       return RoutesBeamStack(
+        debugLabel: '$debugLabel -- ${DateTime.now().millisecondsSinceEpoch}',
         routeInformation: routeInformation,
         routes: routes,
         navBuilder: builder,

--- a/package/lib/src/stack_builders.dart
+++ b/package/lib/src/stack_builders.dart
@@ -56,8 +56,9 @@ class RoutesStackBuilder {
       dynamic Function(
         BuildContext,
         BeamState,
+        // BeamPageNotifier,
+        BeamPageNotifierReference,
         Object?,
-        bool isPinnacle,
       )> routes;
 
   /// Used as a [BeamStack.builder].

--- a/package/lib/src/stack_builders.dart
+++ b/package/lib/src/stack_builders.dart
@@ -7,6 +7,7 @@ import 'package:beamer/src/utils.dart';
 typedef StackBuilder = BeamStack Function(
   RouteInformation,
   BeamParameters?,
+  String creationReason,
 );
 
 /// A pre-made builder to be used for [BeamerDelegate.stackBuilder].
@@ -76,11 +77,13 @@ class RoutesStackBuilder {
   BeamStack call(
     RouteInformation routeInformation,
     BeamParameters? beamParameters,
+    String creationReason,
   ) {
     final matched = RoutesBeamStack.chooseRoutes(routeInformation, routes.keys);
     if (matched.isNotEmpty) {
       return RoutesBeamStack(
         debugLabel: '$debugLabel -- ${DateTime.now().millisecondsSinceEpoch}',
+        creationReason: creationReason,
         routeInformation: routeInformation,
         routes: routes,
         navBuilder: builder,

--- a/package/lib/src/stack_builders.dart
+++ b/package/lib/src/stack_builders.dart
@@ -76,13 +76,11 @@ class RoutesStackBuilder {
     BeamerDelegate parent,
     RouteInformation routeInformation,
     BeamParameters? beamParameters,
-    String creationReason,
   ) {
     final matched = RoutesBeamStack.chooseRoutes(routeInformation, routes.keys);
     if (matched.isNotEmpty) {
       return RoutesBeamStack(
         parent: parent,
-        creationReason: creationReason,
         routeInformation: routeInformation,
         routes: routes,
         navBuilder: builder,


### PR DESCRIPTION
This changes introduces two new related features:

	-	Current pinnacle page info notifications
	-	Current pages state notifications
	
	
Motivation:

In order to understand this changes I will explain my use case: I have a top leve router which handles all the routes and I have three child sibling routers:
	-	Header router
	-	Screen router
	-	Footer router
	
Why having those routers? Because I need to stack some floating layers on top of each (header, screen and footer), and these floating layers must survive (live more than) the routes & beams stacks. This is the reason to have the first feature. It's an optional object passed in the page creation that, in my case, can help to customize those floating layers based on the current visible page (pinnacle page).
	
The second feature is more obvious: To be able to optionally notify every page on every stack state change (E.G. page position in the stack) in push way instead of the more trickier way of listening router changes and compare path. This is done by passing an optional notifier in the page creation.