### PR TITLE
Feature: add `String? path` property and `previousPagePathPop` behavior to `BeamPage`

### DIFF
--- a/package/lib/src/beam_location.dart
+++ b/package/lib/src/beam_location.dart
@@ -496,6 +496,7 @@ class RoutesBeamLocation extends BeamLocation<BeamState> {
       } else {
         return BeamPage(
           key: ValueKey(filteredRoutes[route]),
+          path: filteredRoutes[route],
           child: routeElement,
         );
       }


### PR DESCRIPTION
This aims to improve the expected pop behavior and remove the need for convoluted usage of `popToNamed`.

Instead, we can now specify concrete resolved (_`pathPattern` with filled parameters_) `path` on corresponding `BeamPage` and this is used when determining the path to pop to, if said page would now be on top of the stack. In `RoutesLocationBuilder`, if not wrapping the widget with `BeamPage`, this `path` is put automatically. 

It is also used to specify `Route.name` of the `Route` that the `BeamPage` creates, if no `name` is specified.

The default pop behavior is now `previousPagePathPop` which tries to look at the `path` on `BeamPage` that would be on top of the stack after pop. If the `path` is `null`, we fall back to `pathSegmentPop` as before. If  `popToNamed` is specified on `BeamPage`, it will take priority over any other pop behavior.

---

The following test best demonstrates the added value of this feature for users of `RoutesLocationBuilder`. Previously we had to specify `popToNamed: /` on the second route, which was not always clear, but now the new `path`s set in the background will by default produce a more natural and expected behavior;
```dart
testWidgets('path of previous page is popped to in RoutesLocationBuilder',
    (tester) async {
  final delegate = BeamerDelegate(
    locationBuilder: RoutesLocationBuilder(
      routes: {
        '/': (context, state, data) => Container(),
        '/books/1': (context, state, data) => Container(),
      },
    ),
  );

  await tester.pumpWidget(
    MaterialApp.router(
      routeInformationParser: BeamerParser(),
      routerDelegate: delegate,
    ),
  );
  delegate.beamToNamed('/books/1');
  await tester.pump();
  expect(delegate.currentPages.length, 2);
  expect(delegate.configuration.uri.path, '/books/1');

  delegate.navigator.pop();
  await tester.pump();
  expect(delegate.currentPages.length, 1);
  expect(delegate.configuration.uri.path, '/');
});
```

For users of `BeamLocation`s, it should be more natural to define `path` of the `BeamPage` being popped to than `popToNamed` on the `BeamPage` being popped.

---

In `v2`, the `path` property will most likely become required.
